### PR TITLE
Fix #112, fix doxygen warning

### DIFF
--- a/fsw/inc/cfe_psp_configdata.h
+++ b/fsw/inc/cfe_psp_configdata.h
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_psp_config.h
+ * \file cfe_psp_configdata.h
  *
  *  Created on: Dec 31, 2014
  *      Author: joseph.p.hickey@nasa.gov


### PR DESCRIPTION
**Describe the contribution**
Fix #112, fix doxygen warning 

**Testing performed**
Steps taken to test the contribution:
1. Make usersguide
2. Very warning is gone

**System(s) tested on:**
 - Hardware
 - Ubuntu 18.04
 - doxygen 1.8.13, rc-6.7.0

**Contributor Info**
Anh Van, NASA Goddard

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
