### PR TITLE
Integration Candidate 20191230

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+dist: bionic
+sudo: required
+language:
+  - c
+compiler:
+  - gcc
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - cmake
+
+before_install:
+  - sudo apt-get install cppcheck
+
+script:
+  # Check versions
+  - cppcheck --version
+
+  #cppcheck flight software psp/fsw
+  - cppcheck --force --inline-suppr --std=c99 --language=c --error-exitcode=1 --enable=warning,performance,portability,style --suppress=variableScope --inconclusive fsw 2>cppcheck_flight_psp.txt
+  - |
+    if [[ -s cppcheck_flight_psp.txt ]]; then
+      echo "You must fix cppcheck errors before submitting a pull request"
+      echo ""
+      cat cppcheck_flight_psp.txt
+      exit -1
+    fi
+ 

--- a/fsw/mcp750-vxworks/src/cfe_psp_exception.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_exception.c
@@ -87,7 +87,7 @@ char                  CFE_PSP_ExceptionReasonString[256];
 **
 */
 
-void CFE_PSP_ExceptionHook ( TASK_ID task_id, int vector, void* pEsf );
+void CFE_PSP_ExceptionHook ( TASK_ID task_id, int vector, void* vpEsf );
 
 
 /***************************************************************************

--- a/fsw/modules/eeprom_mmap_file/cfe_psp_eeprom_mmap_file.c
+++ b/fsw/modules/eeprom_mmap_file/cfe_psp_eeprom_mmap_file.c
@@ -190,7 +190,7 @@ void eeprom_mmap_file_Init(uint32 PspModuleId)
        */
        Status = CFE_PSP_MemRangeSet (1, CFE_PSP_MEM_EEPROM, eeprom_address,
                                      eeprom_size, CFE_PSP_MEM_SIZE_DWORD, 0 );
-       OS_printf("CFE_PSP: EEPROM Range (2) created: Start Address = %08lX, Size = %08X\n", (unsigned long)eeprom_address, (unsigned int)eeprom_size);
+       OS_printf("CFE_PSP: EEPROM Range (2) created: Start Address = %08lX, Size = %08X Status = %d\n", (unsigned long)eeprom_address, (unsigned int)eeprom_size, Status);
 
     }
     else

--- a/fsw/pc-linux/src/cfe_psp_memory.c
+++ b/fsw/pc-linux/src/cfe_psp_memory.c
@@ -674,19 +674,37 @@ int32 CFE_PSP_InitProcessorReservedMemory( uint32 RestartType )
    tempFd = open(CFE_PSP_RESERVED_KEY_FILE, O_RDONLY | O_CREAT, S_IRWXU );
    close(tempFd);
       
-   if ( RestartType == CFE_PSP_RST_TYPE_PROCESSOR )
+
+   return_code = CFE_PSP_InitCDS( RestartType );
+   if (return_code != CFE_PSP_SUCCESS)
    {
-      return_code = CFE_PSP_InitCDS( CFE_PSP_RST_TYPE_PROCESSOR );
-      return_code = CFE_PSP_InitResetArea( CFE_PSP_RST_TYPE_PROCESSOR );
-      return_code = CFE_PSP_InitVolatileDiskMem( CFE_PSP_RST_TYPE_PROCESSOR );
-      return_code = CFE_PSP_InitUserReservedArea( CFE_PSP_RST_TYPE_PROCESSOR );
+        OS_printf("CFE_PSP_InitCDS didn't return success (%d)\n", return_code);
+
+        return(return_code);
    }
-   else 
+
+   return_code = CFE_PSP_InitResetArea( RestartType );
+   if (return_code != CFE_PSP_SUCCESS)
    {
-      return_code = CFE_PSP_InitCDS( CFE_PSP_RST_TYPE_POWERON );
-      return_code = CFE_PSP_InitResetArea( CFE_PSP_RST_TYPE_POWERON );
-      return_code = CFE_PSP_InitVolatileDiskMem( CFE_PSP_RST_TYPE_POWERON );
-      return_code = CFE_PSP_InitUserReservedArea( CFE_PSP_RST_TYPE_POWERON );
+        OS_printf("CFE_PSP_InitResetArea didn't return success (%d)\n", return_code);
+
+        return(return_code);
+   }
+
+   return_code = CFE_PSP_InitVolatileDiskMem( RestartType );
+   if (return_code != CFE_PSP_SUCCESS)
+   {
+        OS_printf("CFE_PSP_InitVolatileDiskMem didn't return success (%d)\n", return_code);
+
+        return(return_code);
+   }
+
+   return_code = CFE_PSP_InitUserReservedArea( RestartType );
+   if (return_code != CFE_PSP_SUCCESS)
+   {
+        OS_printf("CFE_PSP_InitVolatileDiskMem didn't return success (%d)\n", return_code);
+
+        return(return_code);
    }
 
    return(return_code);

--- a/fsw/pc-linux/src/cfe_psp_start.c
+++ b/fsw/pc-linux/src/cfe_psp_start.c
@@ -335,8 +335,12 @@ int main(int argc, char *argv[])
    /*
    ** Initialize the reserved memory 
    */
-   CFE_PSP_InitProcessorReservedMemory(reset_type);
-
+   Status = CFE_PSP_InitProcessorReservedMemory(reset_type);
+   if (Status != CFE_PSP_SUCCESS)
+   {
+       OS_printf("CFE_PSP: CFE_PSP_InitProcessorReservedMemory() Failure");
+       CFE_PSP_Panic(Status);
+   }
 
    /*
    ** Call cFE entry point.

--- a/fsw/pc-rtems/src/cfe_psp_exception.c
+++ b/fsw/pc-rtems/src/cfe_psp_exception.c
@@ -130,23 +130,7 @@ void CFE_PSP_AttachExceptions(void)
 void CFE_PSP_ExceptionHook (int task_id, int vector, int32 *pEsf )
 {
 
-    char TaskName[16];
-    
-    /*
-    ** Get the task name
-    */
-    strncpy(TaskName, "TBD", 16);
-    
-    if ( TaskName == NULL )
-    {
-       sprintf(CFE_PSP_ExceptionReasonString, "Exception: Vector=0x%06X, vxWorks Task Name=NULL, Task ID=0x%08X", 
-               vector,task_id);
-    }
-    else
-    {
-       sprintf(CFE_PSP_ExceptionReasonString, "Exception: Vector=0x%06X, vxWorks Task Name=%s, Task ID=0x%08X", 
-                vector, TaskName, task_id);
-    }
+    sprintf(CFE_PSP_ExceptionReasonString, "Not Implemented");
     
     /* 
     ** Save Exception Stack frame 

--- a/fsw/shared/cfe_psp_module.c
+++ b/fsw/shared/cfe_psp_module.c
@@ -108,7 +108,7 @@ int32 CFE_PSP_Module_GetAPIEntry(uint32 PspModuleId, CFE_PSP_ModuleApi_t **API)
  *
  * See prototype for full description
  */
-int32 CFE_PSP_Module_FindByName(const char *DriverName, uint32 *PspModuleId)
+int32 CFE_PSP_Module_FindByName(const char *ModuleName, uint32 *PspModuleId)
 {
     uint32 i;
     int32 Result;
@@ -119,7 +119,7 @@ int32 CFE_PSP_Module_FindByName(const char *DriverName, uint32 *PspModuleId)
     i = 0;
     while (i < CFE_PSP_ModuleCount)
     {
-        if (strcmp(Entry->Name, DriverName) == 0)
+        if (strcmp(Entry->Name, ModuleName) == 0)
         {
             *PspModuleId = CFE_PSP_MODULE_BASE | (i & CFE_PSP_MODULE_INDEX_MASK);
             Result = CFE_PSP_SUCCESS;


### PR DESCRIPTION
**Describe the contribution**
Fix #117, Fix #119

**Testing performed**
1. Checked out all IC 20191230 branches
1. Built and ran cFS unit tests and OSAL coverage (vxworks and shared)
   1. All passed (although osal_timer_UT occasionally still fails due to a test issue)
1. Make cmdUtils where cFS-GroundSystem expects it
   1. cd tools/cFS-GroundSystem/Subsystems/cmdUtil
   1. make
1. Started Ground system
   1. python3 GroundSystem.py
1. Enabled commands to 127.0.0.1
1. Confirmed telemetry packets received
1. Sent ES and TIME noop commands, confirmed noop message from cFS on Port 1
1. Sent ES power on reset and observed cFS exit

**Expected behavior changes**
See related pull requests

**System(s) tested on**
 - cFS Dev Server 2
 - OS: Ubuntu 18.04
 - Versions: ic-20191230 branches

**Additional context**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC