### PR TITLE
Do not directly use a literal for char* members

### DIFF
--- a/fsw/pc-rtems/src/cfe_psp_start.c
+++ b/fsw/pc-rtems/src/cfe_psp_start.c
@@ -105,13 +105,16 @@ rtems_driver_address_table rtems_ramdisk_io_ops =
 rtems_id          RtemsTimerId;
 
 static unsigned char ethernet_address[6] = {0x00, 0x04, 0x9F, 0x00, 0x27, 0x61 };
+static char net_name_str[] = "fxp1";
+static char ip_addr_str[] = "10.0.2.17";
+static char ip_netmask_str[] = "255.255.255.0";
 
 static struct rtems_bsdnet_ifconfig netdriver_config = {
-        .name = "fxp1" /*RTEMS_BSP_NETWORK_DRIVER_NAME*/,
-        .attach = rtems_fxp_attach /*RTEMS_BSP_NETWORK_DRIVER_ATTACH*/,
+        .name = net_name_str,
+        .attach = rtems_fxp_attach,
         .next = NULL,
-        .ip_address = "10.0.2.17",
-        .ip_netmask = "255.255.255.0",
+        .ip_address = ip_addr_str,
+        .ip_netmask = ip_netmask_str,
         .hardware_address = ethernet_address
         /* more options can follow */
 };


### PR DESCRIPTION
**Describe the contribution**

Fix #128

Instead of directly using a literal, declare a static `char[]` variable with the string and use that instead.  This resolves a warning.

**Testing performed**
Build for PC-RTEMS (i686-rtems4.11) and confirm warning is no longer triggered.  Execute CFE using QEMU and confirm that network is functioning normally.

**Expected behavior changes**
No impact to behavior

**System(s) tested on:**
Ubuntu 18.04 build host, i686-rtems4.11 target using pc-rtems PSP.

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
