### PR TITLE
Fix #134: Abstract out path to CFE_SYSTEM_PSPPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,23 +4,26 @@ if (NOT CFE_SYSTEM_PSPNAME)
   message(FATAL_ERROR "CFE_SYSTEM_PSPNAME is not defined - do not know which to build")
 endif()
 
-if (NOT IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/fsw/${CFE_SYSTEM_PSPNAME})
-  message(FATAL_ERROR "PSP ${CFE_SYSTEM_PSPNAME} is not implemented")
+if (NOT CFE_SYSTEM_PSPPATH)
+  set(CFE_SYSTEM_PSPPATH ${CMAKE_CURRENT_SOURCE_DIR}/fsw/${CFE_SYSTEM_PSPNAME})
+endif()
+
+if (NOT IS_DIRECTORY ${CFE_SYSTEM_PSPPATH})
+  message(FATAL_ERROR "PSP ${CFE_SYSTEM_PSPNAME} could not be found at path ${CFE_SYSTEM_PSPPATH}")
 endif()
 
 add_definitions(-D_CFE_PSP_)
-include_directories(fsw/${CFE_SYSTEM_PSPNAME}/inc)
+include_directories(${CFE_SYSTEM_PSPPATH}/inc)
 include_directories(fsw/shared)
-  
+
 # Use all source files under the shared code directory (always)
 # as well as all the files for the selected PSP
 set(PSPFILES)
 aux_source_directory(fsw/shared PSPFILES)
-aux_source_directory(fsw/${CFE_SYSTEM_PSPNAME}/src PSPFILES)
+aux_source_directory(${CFE_SYSTEM_PSPPATH}/src PSPFILES)
 
 add_library(psp-${CFE_SYSTEM_PSPNAME} STATIC ${PSPFILES})
 
 if (ENABLE_UNIT_TESTS)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/fsw/ut-stubs)
 endif (ENABLE_UNIT_TESTS)
-


### PR DESCRIPTION
**Describe the contribution**
This change allows us to move custom PSPs out of tree, so that we don't have to keep a set of patches on top of upstream PSP code.

Future forseeable changes:
- A better, although more involved, solution might involve pulling the shared files in their own library, `psp-shared`, and allowing custom PSPs to be defined entirely out of tree while depending on `psp-shared` as a library. 
- Using targets more extensively would also allow the elegant use of `target_include_directories` with `PRIVATE`, `PUBLIC` and `INTERFACE` descriptors.
- Making the build system less reliant on `aux_source_directory`. The CMake documentation presents the following caveat:
> It is tempting to use this command to avoid writing the list of source files for a library or executable target. While this seems to work, there is no way for CMake to generate a build system that knows when a new source file has been added.

**Testing performed**
Build of the sample cFS configuration.

**Expected behavior changes**
`CFE_SYSTEM_PSPPATH` is introduced as a configuration variable in the build system. If not specified, it will fallback to previous behavior.

**System(s) tested on**
 - PC, Ubuntu 19.04
- current cFS master

**Contributor Info**
Andrei-Costin Zisu of Planetary Transportation Systems GmbH (Berlin, Germany). Company-wide CLA is being signed and will be sent soon.