### PR TITLE
Fix #139, compiler warnings on mcp750 PSP

### DIFF
--- a/fsw/mcp750-vxworks/src/cfe_psp_memory.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_memory.c
@@ -59,7 +59,9 @@
 /*
 ** Define the cFE Core loadable module name
 */
-#define CFE_MODULE_NAME "cfe-core.o"
+#define CFE_MODULE_NAME_DEFAULT "cfe-core.o"
+
+static char CFE_MODULE_NAME[] = CFE_MODULE_NAME_DEFAULT;
 
 
 /*

--- a/fsw/mcp750-vxworks/src/cfe_psp_start.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_start.c
@@ -98,6 +98,7 @@ void CFE_PSP_Main( void )
    uint32 reset_type;
    uint32 reset_subtype;
    char   reset_register;
+   cpuaddr memaddr;
    int32  Status;
 
 
@@ -128,8 +129,14 @@ void CFE_PSP_Main( void )
    /*
    ** Setup the pointer to the reserved area in vxWorks.
    ** This must be done before any of the reset variables are used.
+   **
+   ** Note: this uses a "cpuaddr" (integer address) as an intermediate
+   ** to avoid a warning about alignment.  The output of sysMemTop()
+   ** should be aligned to hold any data type, being the very start
+   ** of the memory space.
    */
-   CFE_PSP_ReservedMemoryPtr = (CFE_PSP_ReservedMemory_t *)sysMemTop();
+   memaddr = (cpuaddr) sysMemTop();
+   CFE_PSP_ReservedMemoryPtr = (CFE_PSP_ReservedMemory_t *) memaddr;
 
    /*
    ** Determine Reset type by reading the hardware reset register.


### PR DESCRIPTION
**Describe the contribution**

Fix #139

Patches for the MCP750 PSP to avoid some compiler warnings that show up when building with strict flags.

**Testing performed**
Build for MCP750 using default config and procedure, confirm warnings are fixed (others still exist in other modules, however).

**Expected behavior changes**
No impact to behavior.  Only fixes warnings.

**System(s) tested on**
 - GSFC build host (gs582w-cfelnx)

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
