### PR TITLE
Fix #135, Add separate CMakeLists.txt for each implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,21 +4,24 @@ if (NOT CFE_SYSTEM_PSPNAME)
   message(FATAL_ERROR "CFE_SYSTEM_PSPNAME is not defined - do not know which to build")
 endif()
 
-if (NOT IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/fsw/${CFE_SYSTEM_PSPNAME})
-  message(FATAL_ERROR "PSP ${CFE_SYSTEM_PSPNAME} is not implemented")
-endif()
-
 add_definitions(-D_CFE_PSP_)
-include_directories(fsw/${CFE_SYSTEM_PSPNAME}/inc)
-include_directories(fsw/shared)
-  
-# Use all source files under the shared code directory (always)
-# as well as all the files for the selected PSP
-set(PSPFILES)
-aux_source_directory(fsw/shared PSPFILES)
-aux_source_directory(fsw/${CFE_SYSTEM_PSPNAME}/src PSPFILES)
 
-add_library(psp-${CFE_SYSTEM_PSPNAME} STATIC ${PSPFILES})
+include_directories(fsw/shared)
+
+# Build the PSP implementation which lies in a system-specific subdirectory
+include_directories(fsw/${CFE_SYSTEM_PSPNAME}/inc)
+add_subdirectory(fsw/${CFE_SYSTEM_PSPNAME} ${CFE_SYSTEM_PSPNAME})
+
+# Build the "common" parts as a library
+add_library(psp-${CFE_SYSTEM_PSPNAME} STATIC
+    fsw/shared/cfe_psp_configdata.c
+    fsw/shared/cfe_psp_eeprom.c
+    fsw/shared/cfe_psp_memrange.c
+    fsw/shared/cfe_psp_memutils.c
+    fsw/shared/cfe_psp_module.c
+    fsw/shared/cfe_psp_port.c
+    fsw/shared/cfe_psp_ram.c
+    $<TARGET_OBJECTS:psp-${CFE_SYSTEM_PSPNAME}-impl>)
 
 if (ENABLE_UNIT_TESTS)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/fsw/ut-stubs)

--- a/fsw/mcp750-vxworks/CMakeLists.txt
+++ b/fsw/mcp750-vxworks/CMakeLists.txt
@@ -1,0 +1,13 @@
+
+# Build the mcp750-vxworks implementation as a library
+add_library(psp-${CFE_SYSTEM_PSPNAME}-impl OBJECT
+    src/cfe_psp_exception.c
+    src/cfe_psp_memory.c
+    src/cfe_psp_memtab.c
+    src/cfe_psp_ssr.c
+    src/cfe_psp_start.c
+    src/cfe_psp_support.c
+    src/cfe_psp_timer.c
+    src/cfe_psp_voltab.c
+    src/cfe_psp_watchdog.c)
+

--- a/fsw/pc-linux/CMakeLists.txt
+++ b/fsw/pc-linux/CMakeLists.txt
@@ -1,0 +1,13 @@
+
+# Build the pc-linux implementation as a library
+add_library(psp-${CFE_SYSTEM_PSPNAME}-impl OBJECT
+    src/cfe_psp_exception.c
+    src/cfe_psp_memory.c
+    src/cfe_psp_memtab.c
+    src/cfe_psp_ssr.c
+    src/cfe_psp_start.c
+    src/cfe_psp_support.c
+    src/cfe_psp_timer.c
+    src/cfe_psp_voltab.c
+    src/cfe_psp_watchdog.c)
+

--- a/fsw/pc-rtems/CMakeLists.txt
+++ b/fsw/pc-rtems/CMakeLists.txt
@@ -1,0 +1,13 @@
+
+# Build the pc-rtems implementation as a library
+add_library(psp-${CFE_SYSTEM_PSPNAME}-impl OBJECT
+    src/cfe_psp_exception.c
+    src/cfe_psp_memory.c
+    src/cfe_psp_memtab.c
+    src/cfe_psp_ssr.c
+    src/cfe_psp_start.c
+    src/cfe_psp_support.c
+    src/cfe_psp_timer.c
+    src/cfe_psp_voltab.c
+    src/cfe_psp_watchdog.c)
+


### PR DESCRIPTION
**Describe the contribution**
Do not use aux_source_directory to assemble a list of source files. Instead, put a proper CMakeLists.txt file in each implementation and build the implementation separately from the shared/common parts.

In addition to avoiding the aux_source_directory this allows PSP-specific compile definitions to be set on a per-implementation basis because it is defined separately.

Fixes #135 

**Testing performed**
Build code for all supported targets (ppc-vxworks6.9, i686-rtems4.11, native/x86-64 linux).  Verify clean build.  Confirm CFE boots and responds to commands as normal.

**Expected behavior changes**
No impact to behavior - changes build script only.

**System(s) tested on**
Ubuntu 18.04 LTS 64-bit + GSFC vxworks build machine

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.