### PR TITLE
Fix #121, Unify CFE PSP with OSAL BSP

### DIFF
--- a/fsw/mcp750-vxworks/make/build_options.cmake
+++ b/fsw/mcp750-vxworks/make/build_options.cmake
@@ -1,11 +1,16 @@
+##########################################################################
+#
+# Build options for "mcp750-vxworks" PSP
+# This file specifies any global-scope compiler options when using this PSP
+#
+##########################################################################
+
 # This indicates where to install target binaries created during the build
+# Note - this should be phased out in favor of the staging dir from OSAL BSP
 set(INSTALL_SUBDIR "cf")
 
-# Additional preprocessor macro definitions to identify this platform
+# Some upper-level code may be gated on _VXWORKS_OS_ being defined
+# This is for compatibility with older build scripts which defined this symbol,
+# but no CFE/OSAL framework code depends on this symbol.
 add_definitions("-D_VXWORKS_OS_")
-add_definitions("-D__PPC__")
-add_definitions("-DMCP750")
 
-include_directories($ENV{WIND_BASE}/target/h)
-include_directories($ENV{WIND_BASE}/target/h/wrn/coreip)
-include_directories($ENV{WIND_BASE}/target/config/mcp750)

--- a/fsw/mcp750-vxworks/src/cfe_psp_start.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_start.c
@@ -80,10 +80,10 @@ IMPORT void sysPciWrite32 (UINT32, UINT32);
 
 
 /******************************************************************************
-**  Function:  CFE_PSP_Main()
+**  Function:  OS_Application_Startup()
 **
 **  Purpose:
-**    vxWorks/BSP Application entry point.
+**    Application startup entry point from OSAL BSP.
 **
 **  Arguments:
 **    (none)
@@ -91,8 +91,7 @@ IMPORT void sysPciWrite32 (UINT32, UINT32);
 **  Return:
 **    (none)
 */
-
-void CFE_PSP_Main( void )
+void OS_Application_Startup(void)
 {
    int    TicksPerSecond;
    uint32 reset_type;
@@ -215,6 +214,24 @@ void CFE_PSP_Main( void )
    ** is complete.
    */
    CFE_PSP_MAIN_FUNCTION(reset_type,reset_subtype, 1, CFE_PSP_NONVOL_STARTUP_FILE);
+
+}
+
+/******************************************************************************
+**  Function:  OS_Application_Run()
+**
+**  Purpose:
+**    Idle Loop entry point from OSAL BSP.
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+void OS_Application_Run(void)
+{
+   int    TicksPerSecond;
 
    /*
    ** Main loop for default task and simulated 1hz 

--- a/fsw/pc-linux/make/build_options.cmake
+++ b/fsw/pc-linux/make/build_options.cmake
@@ -1,6 +1,16 @@
+##########################################################################
+#
+# Build options for "pc-linux" PSP
+# This file specifies any global-scope compiler options when using this PSP
+#
+##########################################################################
+
 # This indicates where to install target binaries created during the build
+# Note - this should be phased out in favor of the staging dir from OSAL BSP
 set(INSTALL_SUBDIR "cf")
 
 # Some upper-level code may be gated on _LINUX_OS_ being defined
+# This is for compatibility with older build scripts which defined this symbol,
+# but no CFE/OSAL framework code depends on this symbol.
 add_definitions("-D_LINUX_OS_")
 

--- a/fsw/pc-linux/src/cfe_psp_start.c
+++ b/fsw/pc-linux/src/cfe_psp_start.c
@@ -157,7 +157,7 @@ static const struct option longOpts[] = {
 **  Return:
 **    (none)
 */
-int main(int argc, char *argv[])
+void OS_Application_Startup(void)
 {
    uint32             reset_type;
    uint32             reset_subtype;
@@ -166,6 +166,8 @@ int main(int argc, char *argv[])
    int                opt = 0;
    int                longIndex = 0;
    int32              Status;
+   char * const *     argv;
+   int                argc;
 
    /*
    ** Initialize the CommandData struct 
@@ -176,6 +178,8 @@ int main(int argc, char *argv[])
    ** Process the arguments with getopt_long(), then 
    ** start the cFE
    */
+   argc = OS_BSP_GetArgC();
+   argv = OS_BSP_GetArgV();
    opt = getopt_long( argc, argv, optString, longOpts, &longIndex );
    while( opt != -1 ) 
    {
@@ -356,6 +360,10 @@ int main(int argc, char *argv[])
        CFE_PSP_SetupLocal1Hz();
    }
 
+}
+
+void OS_Application_Run(void)
+{
    /*
    ** Let the main thread sleep.
    **
@@ -377,9 +385,6 @@ int main(int argc, char *argv[])
    OS_printf("     with a Poweron Reset ( --reset PO ). \n");
 
    OS_DeleteAllObjects();
-
-
-   return(0);
 }
 
 /******************************************************************************

--- a/fsw/pc-rtems/make/build_options.cmake
+++ b/fsw/pc-rtems/make/build_options.cmake
@@ -1,3 +1,17 @@
+##########################################################################
+#
+# Build options for "pc-rtems" PSP
+# This file specifies any global-scope compiler options when using this PSP
+#
+##########################################################################
+
 # This indicates where to install target binaries created during the build
+# Note - this should be phased out in favor of the staging dir from OSAL BSP
 set(INSTALL_SUBDIR "eeprom")
+
+# Some upper-level code may be gated on _RTEMS_OS_ being defined
+# This is for compatibility with older build scripts which defined this symbol,
+# but no CFE/OSAL framework code depends on this symbol.
+add_definitions("-D_RTEMS_OS_")
+
 

--- a/fsw/pc-rtems/src/cfe_psp_start.c
+++ b/fsw/pc-rtems/src/cfe_psp_start.c
@@ -35,20 +35,8 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <rtems.h>
-#include <rtems/mkrootfs.h>
-#include <rtems/bdbuf.h>
-#include <rtems/blkdev.h>
-#include <rtems/diskdevs.h>
-#include <rtems/bdpart.h>
-#include <rtems/error.h>
-#include <rtems/ramdisk.h>
-#include <rtems/dosfs.h>
-#include <rtems/fsmount.h>
-#include <rtems/shell.h>
-#include <rtems/untar.h>
 #include <rtems/rtems_bsdnet.h>
 #include <rtems/rtems_dhcp_failsafe.h>
-#include <rtems/rtl/dlfcn-shell.h>
 #include <bsp.h>
 
 extern int rtems_fxp_attach(struct rtems_bsdnet_ifconfig *config, int attaching);
@@ -61,8 +49,6 @@ extern int rtems_fxp_attach(struct rtems_bsdnet_ifconfig *config, int attaching)
 #include "cfe_psp.h" 
 #include "cfe_psp_memory.h"
 #include "cfe_psp_module.h"
-
-#define RTEMS_NUMBER_OF_RAMDISKS 1
 
 
 /*
@@ -79,28 +65,6 @@ extern int rtems_fxp_attach(struct rtems_bsdnet_ifconfig *config, int attaching)
 ** Global variables
 */
 
-/*
- * The RAM Disk configuration.
- */
-rtems_ramdisk_config rtems_ramdisk_configuration[RTEMS_NUMBER_OF_RAMDISKS];
-
-/*
- * The number of RAM Disk configurations.
-*/
-size_t rtems_ramdisk_configuration_size = RTEMS_NUMBER_OF_RAMDISKS;
-
-/*
-** RAM Disk IO op table.
-*/
-rtems_driver_address_table rtems_ramdisk_io_ops =
-{
-  .initialization_entry = ramdisk_initialize,
-  .open_entry =           rtems_blkdev_generic_open,
-  .close_entry =          rtems_blkdev_generic_close,
-  .read_entry =           rtems_blkdev_generic_read,
-  .write_entry =          rtems_blkdev_generic_write,
-  .control_entry =        rtems_blkdev_generic_ioctl
-};
 
 rtems_id          RtemsTimerId;
 
@@ -157,66 +121,7 @@ int timer_count = 0;
 */
 int CFE_PSP_Setup(void)
 {
-   int status;
-   
-   printf( "\n\n*** RTEMS Info ***\n" );
-   printf("%s", _Copyright_Notice );
-   printf("%s\n\n", _RTEMS_version );
-   printf(" Stack size=%d\n", (int)Configuration.stack_space_size );
-   printf(" Workspace size=%d\n",   (int) Configuration.work_space_size );
-   printf("\n");
-   printf( "*** End RTEMS info ***\n\n" );
-
-   /*
-   ** Create the RTEMS Root file system
-   */
-   status = rtems_create_root_fs();
-   if (status != RTEMS_SUCCESSFUL)
-   {
-       printf("Creating Root file system failed: %s\n",rtems_status_text(status));
-       return status;
-   }
-
-   /*
-   ** create the directory mountpoints
-   */
-   status = mkdir("/ram", S_IFDIR |S_IRWXU | S_IRWXG | S_IRWXO); /* For ramdisk mountpoint */
-   if (status != RTEMS_SUCCESSFUL)
-   {
-       printf("mkdir failed: %s\n", strerror (errno));
-       return status;
-   }
-
-   status = mkdir("/eeprom", S_IFDIR |S_IRWXU | S_IRWXG | S_IRWXO); /* For EEPROM mountpoint */
-   if (status != RTEMS_SUCCESSFUL)
-   {
-       printf("mkdir failed: %s\n", strerror (errno));
-       return status;
-   }
-
-   /*
-    * Register the IDE partition table.
-    * This is _optional_ depending on whether a block device is present.
-    */
-   status = rtems_bdpart_register_from_disk("/dev/hda");
-   if (status != RTEMS_SUCCESSFUL)
-   {
-     printf ("Not mounting block device /dev/hda: %s / %s\n",
-             rtems_status_text (status),strerror(errno));
-   }
-   else
-   {
-       printf ("Mounting block device /dev/hda1 on /eeprom\n");
-       status = mount("/dev/hda1", "/eeprom",
-             RTEMS_FILESYSTEM_TYPE_DOSFS,
-             RTEMS_FILESYSTEM_READ_ONLY,
-             NULL);
-       if (status < 0)
-       {
-         printf ("Mount /eeprom failed: %s\n", strerror (errno));
-         return status;
-       }
-   }
+   rtems_status_code status;
 
    /*
     * Initialize the network.  This is also optional and only
@@ -293,9 +198,7 @@ void CFE_PSP_SetupSystemTimer(void)
 ** In a future version this code may be moved into a separate bsp
 ** integration unit to be more symmetric with the VxWorks implementation.
 */
-rtems_task Init(
-  rtems_task_argument ignored
-)
+void OS_Application_Startup(void)
 {
    if (CFE_PSP_Setup() != RTEMS_SUCCESSFUL)
    {
@@ -303,31 +206,9 @@ rtems_task Init(
    }
 
    /*
-   ** Start the shell early, so it can be be used in case a problem occurs
-   */
-   if (rtems_shell_init("SHLL", RTEMS_MINIMUM_STACK_SIZE * 4, 100, "/dev/console", false, false, NULL) < 0)
-   {
-     printf ("shell init failed: %s\n", strerror (errno));
-   }
-
-   /* give a small delay to let the shell start,
-      avoids having the login prompt show up mid-test,
-      and gives a little time for pending output to actually
-      be sent to the console in case of a slow port */
-   rtems_task_wake_after(50);
-   printf("\n\n\n\n");
-
-   /*
    ** Run the PSP Main - this will return when init is complete
    */
    CFE_PSP_Main();
-
-
-   /*
-   ** Wait for anything interesting to happen
-   **  (any real work should be done by threads spawned during startup)
-   */
-   OS_IdleLoop();
 }
 
 /******************************************************************************
@@ -396,99 +277,3 @@ void CFE_PSP_Main(void)
    CFE_PSP_MAIN_FUNCTION(reset_type,reset_subtype, 1, CFE_PSP_NONVOL_STARTUP_FILE);
 
 }
-
-/* configuration information */
-
-/*
-** RTEMS OS Configuration defintions
-*/
-#define TASK_INTLEVEL 0
-#define CONFIGURE_INIT
-#define CONFIGURE_INIT_TASK_ATTRIBUTES  (RTEMS_FLOATING_POINT | RTEMS_PREEMPT | RTEMS_NO_TIMESLICE | RTEMS_ASR | RTEMS_INTERRUPT_LEVEL(TASK_INTLEVEL))
-#define CONFIGURE_INIT_TASK_STACK_SIZE  (64*1024)
-#define CONFIGURE_INIT_TASK_PRIORITY    120
-
-/*
- * Note that these resources are shared with RTEMS itself (e.g. the init task, the shell)
- * so they should be allocated slightly higher than the user limits in osconfig.h
- *
- * Many RTEMS services use tasks internally, including the idle task, BSWP, ATA driver,
- * low level console I/O, the shell, TCP/IP network stack, and DHCP (if enabled).
- * Many of these also use semaphores for synchronization.
- *
- * Budgeting for additional:
- *   8 internal tasks
- *   2 internal timers
- *   4 internal queues
- *   16 internal semaphores
- *
- */
-#define CONFIGURE_MAXIMUM_TASKS                      (OS_MAX_TASKS + 8)
-#define CONFIGURE_MAXIMUM_TIMERS                     (OS_MAX_TIMERS + 2)
-#define CONFIGURE_MAXIMUM_SEMAPHORES                 (OS_MAX_BIN_SEMAPHORES + OS_MAX_COUNT_SEMAPHORES + OS_MAX_MUTEXES + 16)
-#define CONFIGURE_MAXIMUM_MESSAGE_QUEUES             (OS_MAX_QUEUES + 4)
-
-/*
- * The amount of RAM reserved for the executive workspace.
- * This is for the kernel, and is separate from the C program heap.
- */
-#define CONFIGURE_EXECUTIVE_RAM_SIZE    (2*1024*1024)
-
-#define CONFIGURE_RTEMS_INIT_TASKS_TABLE
-#define CONFIGURE_APPLICATION_NEEDS_CONSOLE_DRIVER
-#define CONFIGURE_APPLICATION_NEEDS_CLOCK_DRIVER
-
-#define CONFIGURE_USE_IMFS_AS_BASE_FILESYSTEM
-#define CONFIGURE_LIBIO_MAXIMUM_FILE_DESCRIPTORS     (OS_MAX_NUM_OPEN_FILES + 8)
-
-#define CONFIGURE_FILESYSTEM_RFS
-#define CONFIGURE_FILESYSTEM_IMFS
-#define CONFIGURE_FILESYSTEM_DOSFS
-#define CONFIGURE_FILESYSTEM_DEVFS
-
-#define CONFIGURE_APPLICATION_NEEDS_LIBBLOCK
-
-#define CONFIGURE_MICROSECONDS_PER_TICK              10000
-
-#define CONFIGURE_MAXIMUM_DRIVERS                   10
-
-#define CONFIGURE_APPLICATION_NEEDS_IDE_DRIVER
-#define CONFIGURE_APPLICATION_NEEDS_ATA_DRIVER
-#define CONFIGURE_ATA_DRIVER_TASK_PRIORITY         9
-
-#define CONFIGURE_MAXIMUM_POSIX_KEYS               4
-
-#include <rtems/confdefs.h>
-
-#define CONFIGURE_SHELL_COMMANDS_INIT
-#define CONFIGURE_SHELL_COMMANDS_ALL
-#define CONFIGURE_SHELL_MOUNT_MSDOS
-
-extern int rtems_rtl_shell_command (int argc, char* argv[]);
-rtems_shell_cmd_t rtems_shell_RTL_Command = {
-  .name = "rtl",
-  .usage = "rtl COMMAND...",
-  .topic = "misc",
-  .command = rtems_rtl_shell_command
-};
-rtems_shell_cmd_t rtems_shell_dlopen_Command = {
-  .name = "dlopen",
-  .usage = "dlopen COMMAND...",
-  .topic = "misc",
-  .command = shell_dlopen
-};
-rtems_shell_cmd_t rtems_shell_dlsym_Command = {
-  .name = "dlsym",
-  .usage = "dlsym COMMAND...",
-  .topic = "misc",
-  .command = shell_dlsym
-};
-#define CONFIGURE_SHELL_USER_COMMANDS   \
-    &rtems_shell_RTL_Command,           \
-    &rtems_shell_dlopen_Command,           \
-    &rtems_shell_dlsym_Command
-
-
-#include <rtems/shellconfig.h>
-
-


### PR DESCRIPTION
**Describe the contribution**
Instead of redefining the basic entry point symbols, use the OSAL BSP and its abstractions.  The CFE PSP just becomes an extension to the OSAL BSP, and only needs to define the OS_Application_Startup symbol like any other OSAL application.

Fixes #121 

**Testing performed**
Build code for all supported targets (ppc-vxworks6.9, i686-rtems4.11, native/x86-64 linux). Verify clean build. Confirm CFE boots and responds to commands as normal for RTEMS and native linux targets.

**Expected behavior changes**
No behavior changes.  Code structure/linking change only.

**System(s) tested on**
Ubuntu 18.04 LTS 64 bit (native, build host)
QEMU for RTEMS 4.11

**Additional context**
VxWorks testing pending on availability of test platform

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.