### PR TITLE
Fix #150, update doxygen comments to fix warnings

### DIFF
--- a/fsw/shared/cfe_psp_configdata.c
+++ b/fsw/shared/cfe_psp_configdata.c
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_psp_config.c
+ * \file cfe_psp_configdata.c
  *
  *  Created on: Dec 31, 2014
  *      Author: joseph.p.hickey@nasa.gov
@@ -35,7 +35,7 @@
  *
  * Because this is compiled within the context of the PSP code,
  * this can access the internal PSP macros directly.  External
- * code such as CFE core or apps would not be able to #include the
+ * code such as CFE core or apps would not be able to \#include the
  * PSP cfe_psp_config.h or psp_version.h files
  */
 Target_PspConfigData GLOBAL_PSP_CONFIGDATA =
@@ -59,4 +59,3 @@ Target_PspConfigData GLOBAL_PSP_CONFIGDATA =
             .MissionRev = CFE_PSP_IMPL_MISSION_REV
       }
 };
-

--- a/fsw/shared/cfe_psp_module.c
+++ b/fsw/shared/cfe_psp_module.c
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file iodriver_manager.c
+ * \file cfe_psp_module.c
  *
  *  Created on: Jul 25, 2014
  *      Author: jphickey
@@ -131,4 +131,3 @@ int32 CFE_PSP_Module_FindByName(const char *ModuleName, uint32 *PspModuleId)
 
     return Result;
 }
-


### PR DESCRIPTION
**Describe the contribution**
Fixes #150
Resolve doxygen warnings

**Testing performed**
Steps taken to test the contribution:
1. Corrected lines that generated warnings
2. Rebuilt documentation with `make doc`
3. Observed no warnings generated
4. Viewed relevant page(s) to verify correctness

**Expected behavior changes**
Changes to documentation only; no code impact

**Contributor Info - All information REQUIRED for consideration of pull request**
Leor Bleier, NASA\GSFC
