### PR TITLE
Integration Candidate: 2020-05-27

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ This is a collection of APIs abstracting platform specific functionality to be l
 
 ## Version History
 
+### Development Build: 1.4.12
+
+- Replace 'OS_VolumeTable' with OS_FileSysAddFixedMap() in all PSPs.
+- See <https://github.com/nasa/PSP/pull/166> 
+
 ### Development Build: 1.4.11
 
 - Removes non-termination string warnings when building with GCC9.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ This is a collection of APIs abstracting platform specific functionality to be l
 
 ## Version History
 
+### Development Build: 1.4.13
+
+- Changes the PSP reference to be compatible with the change in nasa/osal#449 making the BSP modules more generic and changes the name.
+- See <https://github.com/nasa/PSP/pull/167>
+
 ### Development Build: 1.4.12
 
 - Replace 'OS_VolumeTable' with OS_FileSysAddFixedMap() in all PSPs.

--- a/fsw/mcp750-vxworks/inc/psp_version.h
+++ b/fsw/mcp750-vxworks/inc/psp_version.h
@@ -35,7 +35,7 @@
 */
 #define CFE_PSP_IMPL_MAJOR_VERSION          1
 #define CFE_PSP_IMPL_MINOR_VERSION          4
-#define CFE_PSP_IMPL_REVISION               11
+#define CFE_PSP_IMPL_REVISION               12
 #define CFE_PSP_IMPL_MISSION_REV            0
 
 #endif  /* _psp_version_ */

--- a/fsw/mcp750-vxworks/inc/psp_version.h
+++ b/fsw/mcp750-vxworks/inc/psp_version.h
@@ -35,7 +35,7 @@
 */
 #define CFE_PSP_IMPL_MAJOR_VERSION          1
 #define CFE_PSP_IMPL_MINOR_VERSION          4
-#define CFE_PSP_IMPL_REVISION               12
+#define CFE_PSP_IMPL_REVISION               13
 #define CFE_PSP_IMPL_MISSION_REV            0
 
 #endif  /* _psp_version_ */

--- a/fsw/mcp750-vxworks/make/build_options.cmake
+++ b/fsw/mcp750-vxworks/make/build_options.cmake
@@ -14,3 +14,18 @@ set(INSTALL_SUBDIR "cf")
 # but no CFE/OSAL framework code depends on this symbol.
 add_definitions("-D_VXWORKS_OS_")
 
+
+# Use the mcp750-specific VxWorks BSP include directory
+# This needs to be globally used, not just private to the PSP, because
+# some VxWorks headers reference files contained here.
+include_directories(
+    ${WIND_BASE}/target/config/mcp750
+)
+
+# NOTE: the __PPC__ and MCP750 macros are referenced in some system headers.
+# therefore all code compiled for this platform should always define these symbols.
+add_definitions("-D__PPC__")
+add_definitions("-DMCP750")
+
+set(CFE_PSP_EXPECTED_OSAL_BSPTYPE "generic-vxworks")
+

--- a/fsw/pc-linux/inc/psp_version.h
+++ b/fsw/pc-linux/inc/psp_version.h
@@ -35,7 +35,7 @@
 */
 #define CFE_PSP_IMPL_MAJOR_VERSION          1
 #define CFE_PSP_IMPL_MINOR_VERSION          4
-#define CFE_PSP_IMPL_REVISION               11
+#define CFE_PSP_IMPL_REVISION               12
 #define CFE_PSP_IMPL_MISSION_REV            0
 
 #endif  /* _psp_version_ */

--- a/fsw/pc-linux/inc/psp_version.h
+++ b/fsw/pc-linux/inc/psp_version.h
@@ -35,7 +35,7 @@
 */
 #define CFE_PSP_IMPL_MAJOR_VERSION          1
 #define CFE_PSP_IMPL_MINOR_VERSION          4
-#define CFE_PSP_IMPL_REVISION               12
+#define CFE_PSP_IMPL_REVISION               13
 #define CFE_PSP_IMPL_MISSION_REV            0
 
 #endif  /* _psp_version_ */

--- a/fsw/pc-linux/make/build_options.cmake
+++ b/fsw/pc-linux/make/build_options.cmake
@@ -14,3 +14,5 @@ set(INSTALL_SUBDIR "cf")
 # but no CFE/OSAL framework code depends on this symbol.
 add_definitions("-D_LINUX_OS_")
 
+set(CFE_PSP_EXPECTED_OSAL_BSPTYPE "generic-linux")
+

--- a/fsw/pc-rtems/inc/psp_version.h
+++ b/fsw/pc-rtems/inc/psp_version.h
@@ -35,7 +35,7 @@
 */
 #define CFE_PSP_IMPL_MAJOR_VERSION          1
 #define CFE_PSP_IMPL_MINOR_VERSION          4
-#define CFE_PSP_IMPL_REVISION               11
+#define CFE_PSP_IMPL_REVISION               12
 #define CFE_PSP_IMPL_MISSION_REV            0
 
 #endif  /* _psp_version_ */

--- a/fsw/pc-rtems/inc/psp_version.h
+++ b/fsw/pc-rtems/inc/psp_version.h
@@ -35,7 +35,7 @@
 */
 #define CFE_PSP_IMPL_MAJOR_VERSION          1
 #define CFE_PSP_IMPL_MINOR_VERSION          4
-#define CFE_PSP_IMPL_REVISION               12
+#define CFE_PSP_IMPL_REVISION               13
 #define CFE_PSP_IMPL_MISSION_REV            0
 
 #endif  /* _psp_version_ */


### PR DESCRIPTION
**Describe the contribution**
Fix #162 

**Testing performed**
https://github.com/nasa/cFS/pull/96/checks

**Expected behavior changes**
PR #164 - This changes the PSP reference to be compatible with the change in nasa/osal#449 making the BSP modules more generic and changes the name. 

**System(s) tested on**
Ubuntu:Bionic

**Additional context**
Part of nasa/cfs#96

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.