### PR TITLE
Fix #170, set exception context size

### DIFF
--- a/fsw/mcp750-vxworks/src/cfe_psp_exception.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_exception.c
@@ -141,6 +141,12 @@ void CFE_PSP_ExceptionHook (TASK_ID task_id, int vector, void* vpEsf )
          */
         fppSave(&Buffer->context_info.fp);
 
+        /*
+         * Save total size of context info.
+         * (This PSP always fills the entire structure)
+         */
+        Buffer->context_size = sizeof(Buffer->context_info);
+
         CFE_PSP_Exception_WriteComplete();
     }
 


### PR DESCRIPTION
**Describe the contribution**
Store the size of the stored data into the exception record on mcp750-vxworks platform.

Fixes #170 

**Testing performed**
Build and sanity test CFE.
Unit testing via PSP coverage tests (separately in issue #168)

**Expected behavior changes**
The exception context stored on MCP750 has a valid size.

**System(s) tested on**
Ubuntu 20.04 running coverage tests for MCP750.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
