### PR TITLE
Resolve #177, Add baseline and build to version.h

### DIFF
--- a/fsw/inc/cfe_psp.h
+++ b/fsw/inc/cfe_psp.h
@@ -137,11 +137,13 @@
 #define CFE_PSP_RST_SUBTYPE_MAX                   10  /**< \brief  Placeholder to indicate 1+ the maximum value that the PSP will ever use. */
 /** \} */
 
+
 /* Implement the "version" macros */
 #define CFE_PSP_MAJOR_VERSION          (GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.MajorVersion)
 #define CFE_PSP_MINOR_VERSION          (GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.MinorVersion)
 #define CFE_PSP_REVISION               (GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.Revision)
 #define CFE_PSP_MISSION_REV            (GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.MissionRev)
+#define CFE_PSP_VERSION                (GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.Version)
 
 /*
 ** Type Definitions

--- a/fsw/inc/cfe_psp_configdata.h
+++ b/fsw/inc/cfe_psp_configdata.h
@@ -43,6 +43,7 @@ typedef const struct
    uint8 MinorVersion;
    uint8 Revision;
    uint8 MissionRev;
+   char  Version[16];
 } CFE_PSP_VersionInfo_t;
 
 

--- a/fsw/mcp750-vxworks/inc/psp_version.h
+++ b/fsw/mcp750-vxworks/inc/psp_version.h
@@ -19,23 +19,62 @@
 */
 
 /*
-**  File: psp_version.h
-**
-**  Purpose:
-**  Provide version identifiers for the cFE Platform Support Packages (PSP).
-**
-*/
+ *  File: psp_version.h
+ *
+ *  Purpose:
+ *  Provide version identifiers for the cFE Platform Support Packages (PSP).
+ *  See cfe documentation for version and build number descriptions
+ *
+ */
 
 #ifndef _psp_version_
 #define _psp_version_
 
+/* Development Build Macro Definitions */
+#define CFE_PSP_IMPL_BUILD_NUMBER 68
+#define CFE_PSP_IMPL_BUILD_BASELINE "v1.4.0+dev"
 
 /*
-** Macro Definitions
-*/
-#define CFE_PSP_IMPL_MAJOR_VERSION          1
-#define CFE_PSP_IMPL_MINOR_VERSION          4
-#define CFE_PSP_IMPL_REVISION               14
-#define CFE_PSP_IMPL_MISSION_REV            0
+ * Macro Definitions
+ * ONLY APPLY for OFFICIAL releases
+ */
+#define CFE_PSP_IMPL_MAJOR_VERSION 1
+#define CFE_PSP_IMPL_MINOR_VERSION 4
+#define CFE_PSP_IMPL_REVISION      0
+#define CFE_PSP_IMPL_MISSION_REV   0
 
+#define CFE_PSP_IMPL_STR_HELPER(x) #x
+#define CFE_PSP_IMPL_STR(x)        CFE_PSP_IMPL_STR_HELPER(x)
+
+/* Baseling git tag + Number of commits since baseline */
+#define CFE_PSP_IMPL_VERSION CFE_PSP_IMPL_BUILD_BASELINE CFE_PSP_IMPL_STR(CFE_PSP_IMPL_BUILD_NUMBER)
+
+#define CFE_PSP_IMPL_VERSION_STRING                                                                      \
+    " PSP Development Build\n " CFE_PSP_IMPL_VERSION " (Codename: Bootes)" /* Codename for current development */ \
+    "\n Last Official Release: psp v1.4.0"                        /* For full support please use this version */
+
+/* Use the following templates for Official Releases ONLY */
+
+/* Official Release format for CFE_PSP_IMPLVERSION */
+  /*
+  #define CFE_PSP_IMPL_VERSION "v"            \
+       CFE_PSP_IMPL_STR(CFE_PSP_IMPL_MAJOR_VERSION) "." \
+       CFE_PSP_IMPL_STR(CFE_PSP_IMPL_MINOR_VERSION) "." \
+       CFE_PSP_IMPL_STR(CFE_PSP_IMPL_REVISION) "."      \
+       CFE_PSP_IMPL_STR(CFE_PSP_IMPL_MISSION_REV)
+  */
+
+/* Official Release CFE_PSP_IMPLVERSION_STRING Format */
+/*
+#define CFE_PSP_IMPL_VERSION_STRING " PSP " CFE_PSP_IMPL_VERSION
+*/
+
+
+  /* Official Release CFE_PSP_IMPLVERSION_STRING Format */
+  /*
+  #define CFE_PSP_IMPL_VERSION_STRING " PSP " CFE_PSP_IMPLVERSION
+  */
+  
+/* END TEMPLATES */
+    
 #endif  /* _psp_version_ */

--- a/fsw/pc-linux/inc/psp_version.h
+++ b/fsw/pc-linux/inc/psp_version.h
@@ -19,23 +19,56 @@
 */
 
 /*
-**  File: psp_version.h
-**
-**  Purpose:
-**  Provide version identifiers for the cFE Platform Support Packages (PSP).
-**
-*/
+ *  File: psp_version.h
+ *
+ *  Purpose:
+ *  Provide version identifiers for the cFE Platform Support Packages (PSP).
+ *  See cfe documentation for version and build number descriptions
+ *
+ */
 
 #ifndef _psp_version_
 #define _psp_version_
 
+/* Development Build Macro Definitions */
+#define CFE_PSP_IMPL_BUILD_NUMBER 68
+#define CFE_PSP_IMPL_BUILD_BASELINE "v1.4.0+dev"
 
 /*
-** Macro Definitions
-*/
-#define CFE_PSP_IMPL_MAJOR_VERSION          1
-#define CFE_PSP_IMPL_MINOR_VERSION          4
-#define CFE_PSP_IMPL_REVISION               14
-#define CFE_PSP_IMPL_MISSION_REV            0
+ * Macro Definitions
+ * ONLY APPLY for OFFICIAL releases
+ */
+#define CFE_PSP_IMPL_MAJOR_VERSION 1
+#define CFE_PSP_IMPL_MINOR_VERSION 4
+#define CFE_PSP_IMPL_REVISION      0
+#define CFE_PSP_IMPL_MISSION_REV   0
+
+#define CFE_PSP_IMPL_STR_HELPER(x) #x
+#define CFE_PSP_IMPL_STR(x)        CFE_PSP_IMPL_STR_HELPER(x)
+
+/* Baseling git tag + Number of commits since baseline */
+#define CFE_PSP_IMPL_VERSION CFE_PSP_IMPL_BUILD_BASELINE CFE_PSP_IMPL_STR(CFE_PSP_IMPL_BUILD_NUMBER)
+
+#define CFE_PSP_IMPL_VERSION_STRING                                                                      \
+    " PSP Development Build\n " CFE_PSP_IMPL_VERSION " (Codename: Bootes)" /* Codename for current development */ \
+    "\n Last Official Release: psp v1.4.0"                        /* For full support please use this version */
+
+/* Use the following templates for Official Releases ONLY */
+
+/* Official Release format for CFE_PSP_IMPLVERSION */
+  /*
+  #define CFE_PSP_IMPL_VERSION "v"            \
+       CFE_PSP_IMPL_STR(CFE_PSP_IMPL_MAJOR_VERSION) "." \
+       CFE_PSP_IMPL_STR(CFE_PSP_IMPL_MINOR_VERSION) "." \
+       CFE_PSP_IMPL_STR(CFE_PSP_IMPL_REVISION) "."      \
+       CFE_PSP_IMPL_STR(CFE_PSP_IMPL_MISSION_REV)
+  */
+
+  /* Official Release CFE_PSP_IMPLVERSION_STRING Format */
+  /*
+  #define CFE_PSP_IMPL_VERSION_STRING " PSP " CFE_PSP_IMPL_VERSION
+  */
+  
+/* END TEMPLATES */
 
 #endif  /* _psp_version_ */

--- a/fsw/pc-rtems/inc/psp_version.h
+++ b/fsw/pc-rtems/inc/psp_version.h
@@ -19,23 +19,57 @@
 */
 
 /*
-**  File: psp_version.h
-**
-**  Purpose:
-**  Provide version identifiers for the cFE Platform Support Packages (PSP).
-**
-*/
+ *  File: psp_version.h
+ *
+ *  Purpose:
+ *  Provide version identifiers for the cFE Platform Support Packages (PSP).
+ *  See cfe documentation for version and build number descriptions
+ *
+ */
 
 #ifndef _psp_version_
 #define _psp_version_
 
+/* Development Build Macro Definitions */
+#define CFE_PSP_IMPL_BUILD_NUMBER 68
+#define CFE_PSP_IMPL_BUILD_BASELINE "v1.4.0+dev"
 
 /*
-** Macro Definitions
-*/
-#define CFE_PSP_IMPL_MAJOR_VERSION          1
-#define CFE_PSP_IMPL_MINOR_VERSION          4
-#define CFE_PSP_IMPL_REVISION               14
-#define CFE_PSP_IMPL_MISSION_REV            0
+ * Macro Definitions
+ * ONLY APPLY for OFFICIAL releases
+ */
+#define CFE_PSP_IMPL_MAJOR_VERSION 1
+#define CFE_PSP_IMPL_MINOR_VERSION 4
+#define CFE_PSP_IMPL_REVISION      0
+#define CFE_PSP_IMPL_MISSION_REV   0
 
+#define CFE_PSP_IMPL_STR_HELPER(x) #x
+#define CFE_PSP_IMPL_STR(x)        CFE_PSP_IMPL_STR_HELPER(x)
+
+/* Baseling git tag + Number of commits since baseline */
+#define CFE_PSP_IMPL_VERSION CFE_PSP_IMPL_BUILD_BASELINE CFE_PSP_IMPL_STR(CFE_PSP_IMPL_BUILD_NUMBER)
+
+#define CFE_PSP_IMPL_VERSION_STRING                                                                      \
+    " PSP Development Build\n " CFE_PSP_IMPL_VERSION " (Codename: Bootes)" /* Codename for current development */ \
+    "\n Last Official Release: psp v1.4.0"                        /* For full support please use this version */
+
+/* Use the following templates for Official Releases ONLY */
+
+/* Official Release format for CFE_PSP_IMPLVERSION */
+  /*
+  #define CFE_PSP_IMPL_VERSION "v"            \
+       CFE_PSP_IMPL_STR(CFE_PSP_IMPL_MAJOR_VERSION) "." \
+       CFE_PSP_IMPL_STR(CFE_PSP_IMPL_MINOR_VERSION) "." \
+       CFE_PSP_IMPL_STR(CFE_PSP_IMPL_REVISION) "."      \
+       CFE_PSP_IMPL_STR(CFE_PSP_IMPL_MISSION_REV)
+  */
+
+  /* Official Release CFE_PSP_IMPLVERSION_STRING Format */
+  /*
+  #define CFE_PSP_IMPL_VERSION_STRING " PSP " CFE_PSP_IMPL_VERSION
+  */
+
+  
+/* END TEMPLATES */
+    
 #endif  /* _psp_version_ */

--- a/fsw/shared/src/cfe_psp_configdata.c
+++ b/fsw/shared/src/cfe_psp_configdata.c
@@ -52,6 +52,7 @@ Target_PspConfigData GLOBAL_PSP_CONFIGDATA =
             .MajorVersion = CFE_PSP_IMPL_MAJOR_VERSION,
             .MinorVersion = CFE_PSP_IMPL_MINOR_VERSION,
             .Revision = CFE_PSP_IMPL_REVISION,
-            .MissionRev = CFE_PSP_IMPL_MISSION_REV
+            .MissionRev = CFE_PSP_IMPL_MISSION_REV,
+            .Version = CFE_PSP_IMPL_VERSION
       }
 };


### PR DESCRIPTION
**Describe the contribution**
Resolve #177 

**Testing performed**
Steps taken to test the contribution:
Built on top of current integration candidate
Built with other integration candidates as well as with nasa/osal#532 and nasa/cfe#771

**Expected behavior changes**
New macros defined. No changes on it's own. When combined with nasa/cfe#771 and nasa/osal#532 then startup reporting now looks like 
<img width="331" alt="Screen Shot 2020-07-15 at 8 56 43 AM" src="https://user-images.githubusercontent.com/59618057/87557256-ab977000-c685-11ea-893c-a27e54441639.png">
<img width="340" alt="Screen Shot 2020-07-15 at 8 56 52 AM" src="https://user-images.githubusercontent.com/59618057/87557332-c5d14e00-c685-11ea-8fd7-4ad987984e72.png">
<img width="208" alt="Screen Shot 2020-07-15 at 8 56 35 AM" src="https://user-images.githubusercontent.com/59618057/87557452-ebf6ee00-c685-11ea-8914-c4ea6844fde4.png">


**System(s) tested on**
Docker Ubuntu-based gcc image on OSX

**Additional context**
Also Tested with nasa/osal#532 and nasa/cfe#771

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Gerardo E. Cruz-Ortiz, NASA-GSFC