### PR TITLE
Fix #187, Set stub spacecraft ID to historical value (0x42)

### DIFF
--- a/ut-stubs/ut_psp_stubs.c
+++ b/ut-stubs/ut_psp_stubs.c
@@ -58,7 +58,7 @@ Target_ConfigData GLOBAL_CONFIGDATA =
         .User = "MissionBuildUser",
         .Default_CpuName = "UnitTestCpu",
         .Default_CpuId = 1,
-        .Default_SpacecraftId = 42,
+        .Default_SpacecraftId = 0x42,
         .CfeConfig = &GLOBAL_CFE_CONFIGDATA,
         .PspConfig = &GLOBAL_PSP_CONFIGDATA
 };


### PR DESCRIPTION
**Describe the contribution**
Fix #187 - set the stub config data spacecraft id to historical value 0x42, was 42.

**Testing performed**
Nominal build/test, passed.

**Expected behavior changes**
Anything using the stub config data will now get the default.  The point is really to reduce confusion the mismatch could cause.  Nothing should actually be using this stub data directly.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle main (+ cfe/osal main) + this change

**Additional context**
nasa/cfe#828

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC