### PR TITLE
Fix #165, Add CFE_PSP_GetProcessorName

### DIFF
--- a/fsw/inc/cfe_psp.h
+++ b/fsw/inc/cfe_psp.h
@@ -216,6 +216,10 @@ extern uint32        CFE_PSP_GetSpacecraftId ( void );
 ** CFE_PSP_GetSpacecraftId retuns the Spacecraft ID (if any )
 */
 
+extern const char *  CFE_PSP_GetProcessorName(void);
+/*
+** CFE_PSP_GetProcessorName returns the processor name
+*/
 
 extern uint32 CFE_PSP_Get_Timer_Tick(void);
 /*

--- a/fsw/mcp750-vxworks/src/cfe_psp_support.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_support.c
@@ -66,6 +66,7 @@
 #include <target_config.h>
 
 #define CFE_PSP_CPU_ID               (GLOBAL_CONFIGDATA.Default_CpuId)
+#define CFE_PSP_CPU_NAME             (GLOBAL_CONFIGDATA.Default_CpuName)
 #define CFE_PSP_SPACECRAFT_ID        (GLOBAL_CONFIGDATA.Default_SpacecraftId)
 
 /*
@@ -190,5 +191,25 @@ uint32 CFE_PSP_GetProcessorId    (void)
 uint32 CFE_PSP_GetSpacecraftId   (void)
 {
    return CFE_PSP_SPACECRAFT_ID;
+}
+
+/*
+** Name: CFE_PSP_GetProcessorName
+**
+** Purpose:
+**         return the processor name.
+**
+** Parameters:
+**
+** Global Inputs: None
+**
+** Global Outputs: None
+**
+**
+** Return Values: Processor name
+*/
+const char *CFE_PSP_GetProcessorName   (void)
+{
+   return CFE_PSP_CPU_NAME;
 }
 

--- a/fsw/pc-linux/src/cfe_psp_support.c
+++ b/fsw/pc-linux/src/cfe_psp_support.c
@@ -52,6 +52,7 @@
 */
 extern uint32  CFE_PSP_SpacecraftId;
 extern uint32  CFE_PSP_CpuId;
+extern char    CFE_PSP_CpuName[];
 
 
 /******************************************************************************
@@ -200,3 +201,24 @@ uint32 CFE_PSP_GetSpacecraftId   (void)
 {
    return(CFE_PSP_SpacecraftId);
 }
+
+/*
+** Name: CFE_PSP_GetProcessorName
+**
+** Purpose:
+**         return the processor name.
+**
+** Parameters:
+**
+** Global Inputs: None
+**
+** Global Outputs: None
+**
+**
+** Return Values: Processor name
+*/
+const char *CFE_PSP_GetProcessorName   (void)
+{
+   return(CFE_PSP_CpuName);
+}
+

--- a/fsw/pc-rtems/src/cfe_psp_support.c
+++ b/fsw/pc-rtems/src/cfe_psp_support.c
@@ -179,3 +179,23 @@ uint32 CFE_PSP_GetSpacecraftId   (void)
    return(CFE_PSP_SPACECRAFT_ID);
 }
 
+/*
+** Name: CFE_PSP_GetProcessorName
+**
+** Purpose:
+**         return the processor name.
+**
+** Parameters:
+**
+** Global Inputs: None
+**
+** Global Outputs: None
+**
+**
+** Return Values: Processor name
+*/
+const char *CFE_PSP_GetProcessorName   (void)
+{
+   return(CFE_PSP_CPU_NAME);
+}
+

--- a/ut-stubs/ut_psp_stubs.c
+++ b/ut-stubs/ut_psp_stubs.c
@@ -145,6 +145,37 @@ uint32 CFE_PSP_GetSpacecraftId(void)
 
 /*****************************************************************************/
 /**
+** \brief CFE_PSP_GetProcessorName stub function
+**
+** \par Description
+**        This function is used as a placeholder for the PSP function
+**        CFE_PSP_GetProcessorName.  It is set to return a fixed value for the
+**        unit tests.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        Returns Default_CpuName or passed in address from buffer
+**
+******************************************************************************/
+const char *CFE_PSP_GetProcessorName(void)
+{
+    int32      status;
+    const char *ptr = GLOBAL_CONFIGDATA.Default_CpuName;
+
+    status = UT_DEFAULT_IMPL(CFE_PSP_GetProcessorName);
+
+    if (status >= 0)
+    {
+        UT_Stub_CopyToLocal(UT_KEY(CFE_PSP_GetProcessorName), &ptr, sizeof(ptr));
+    }
+
+    return ptr;
+}
+
+/*****************************************************************************/
+/**
 v** \brief CFE_PSP_GetTime stub function
 **
 ** \par Description


### PR DESCRIPTION
**Describe the contribution**
Fix #165 - Add CFE_PSP_GetProcessorName

**Testing performed**
Added test code in sample_app to output SC ID, CPU ID, and CPU NAME
Build and ran (pc-linux only), tested with both default options and `./core-cpu1 --cpuid=2 --scid=40 --cpuname="bleh"`, confirmed expected output

**Expected behavior changes**
Now provides get processor name API

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle main (+ cfe/osal main) + this change.

**Additional context**
nasa/cFE#827

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC