### PR TITLE
Fix #194, Install unit test to target directories

### DIFF
--- a/unit-test-coverage/mcp750-vxworks/CMakeLists.txt
+++ b/unit-test-coverage/mcp750-vxworks/CMakeLists.txt
@@ -58,6 +58,6 @@ target_link_libraries(coverage-${CFE_PSP_TARGETNAME}-testrunner
 add_test(coverage-${CFE_PSP_TARGETNAME} coverage-${CFE_PSP_TARGETNAME}-testrunner)
 
 foreach(TGT ${INSTALL_TARGET_LIST})
-    install(TARGETS coverage-${CFE_PSP_TARGETNAME}-testrunner DESTINATION ${TGTNAME}/${UT_INSTALL_SUBDIR})
+    install(TARGETS coverage-${CFE_PSP_TARGETNAME}-testrunner DESTINATION ${TGT}/${UT_INSTALL_SUBDIR})
 endforeach()
 


### PR DESCRIPTION
**Describe the contribution**
Fix #194, Install unit test to target directories

**Testing performed**
Make unit tests, install, observe they install in correct directory

**Expected behavior changes**
Correct install directory

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC