### PR TITLE
Integration Candidate 2020-09-16

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This is a collection of APIs abstracting platform specific functionality to be l
 
 ## Version History
 
+### Development Build: 1.5.0-rc1+dev14
+
+- Sets the stub config data spacecraft id to historical value 0x42, was 42.
+- Installs unit test to target directories.
+- See <https://github.com/nasa/PSP/pull/196>
+
 ### Development Build: 1.5.0-rc1+dev6
 
 - Adds CFE_PSP_GetProcessorName

--- a/fsw/mcp750-vxworks/inc/psp_version.h
+++ b/fsw/mcp750-vxworks/inc/psp_version.h
@@ -29,8 +29,8 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 76
-#define CFE_PSP_IMPL_BUILD_BASELINE "v1.4.0+dev"
+#define CFE_PSP_IMPL_BUILD_NUMBER 14
+#define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*
  * Version Macro Definitions

--- a/fsw/pc-linux/inc/psp_version.h
+++ b/fsw/pc-linux/inc/psp_version.h
@@ -29,8 +29,8 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 76
-#define CFE_PSP_IMPL_BUILD_BASELINE "v1.4.0+dev"
+#define CFE_PSP_IMPL_BUILD_NUMBER 14
+#define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*
  * Version Macro Definitions

--- a/fsw/pc-rtems/inc/psp_version.h
+++ b/fsw/pc-rtems/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 6
+#define CFE_PSP_IMPL_BUILD_NUMBER 14
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/unit-test-coverage/mcp750-vxworks/CMakeLists.txt
+++ b/unit-test-coverage/mcp750-vxworks/CMakeLists.txt
@@ -58,6 +58,6 @@ target_link_libraries(coverage-${CFE_PSP_TARGETNAME}-testrunner
 add_test(coverage-${CFE_PSP_TARGETNAME} coverage-${CFE_PSP_TARGETNAME}-testrunner)
 
 foreach(TGT ${INSTALL_TARGET_LIST})
-    install(TARGETS coverage-${CFE_PSP_TARGETNAME}-testrunner DESTINATION ${TGTNAME}/${UT_INSTALL_SUBDIR})
+    install(TARGETS coverage-${CFE_PSP_TARGETNAME}-testrunner DESTINATION ${TGT}/${UT_INSTALL_SUBDIR})
 endforeach()
 

--- a/ut-stubs/ut_psp_stubs.c
+++ b/ut-stubs/ut_psp_stubs.c
@@ -58,7 +58,7 @@ Target_ConfigData GLOBAL_CONFIGDATA =
         .User = "MissionBuildUser",
         .Default_CpuName = "UnitTestCpu",
         .Default_CpuId = 1,
-        .Default_SpacecraftId = 42,
+        .Default_SpacecraftId = 0x42,
         .CfeConfig = &GLOBAL_CFE_CONFIGDATA,
         .PspConfig = &GLOBAL_PSP_CONFIGDATA
 };


### PR DESCRIPTION
**Describe the contribution**
Fix #187 
Fix #194 

**Testing performed**
Bundle CI - https://github.com/nasa/cFS/pull/140/checks

**Expected behavior changes**
PR #191 - Sets the stub config data spacecraft id to historical value 0x42, was 42.

PR #195 - Installs unit test to target directories.

**System(s) tested on**
Ubuntu - CI

**Additional context**
 https://github.com/nasa/cFS/pull/140


**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman, NASA-GSFC

