### PR TITLE
Fix #200, Update PSP to use osal_id_t

### DIFF
--- a/fsw/inc/cfe_psp.h
+++ b/fsw/inc/cfe_psp.h
@@ -366,7 +366,7 @@ extern void CFE_PSP_SetDefaultExceptionEnvironment(void);
 
 
 extern uint32 CFE_PSP_Exception_GetCount(void);
-extern int32 CFE_PSP_Exception_GetSummary(uint32 *ContextLogId, uint32 *TaskId, char *ReasonBuf, uint32 ReasonSize);
+extern int32 CFE_PSP_Exception_GetSummary(uint32 *ContextLogId, osal_id_t *TaskId, char *ReasonBuf, uint32 ReasonSize);
 extern int32 CFE_PSP_Exception_CopyContext(uint32 ContextLogId, void *ContextBuf, uint32 ContextSize);
 
 /*

--- a/fsw/mcp750-vxworks/src/cfe_psp_start.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_start.c
@@ -96,7 +96,7 @@ void OS_Application_Startup(void)
    int    TicksPerSecond;
    uint32 reset_type;
    uint32 reset_subtype;
-   uint32 fs_id;
+   osal_id_t fs_id;
    char   reset_register;
    int32  Status;
 

--- a/fsw/pc-linux/src/cfe_psp_start.c
+++ b/fsw/pc-linux/src/cfe_psp_start.c
@@ -159,8 +159,8 @@ void OS_Application_Startup(void)
    uint32             reset_type;
    uint32             reset_subtype;
    int32              time_status;
-   uint32             sys_timebase_id;
-   uint32             fs_id;
+   osal_id_t          sys_timebase_id;
+   osal_id_t          fs_id;
    int                opt = 0;
    int                longIndex = 0;
    int32              Status;
@@ -319,7 +319,7 @@ void OS_Application_Startup(void)
         *
         * See below for workaround.
         */
-       sys_timebase_id = 0;
+       sys_timebase_id = OS_OBJECT_ID_UNDEFINED;
    }
 
    /*
@@ -403,7 +403,7 @@ void OS_Application_Startup(void)
    /*
     * Backward compatibility for old OSAL.
     */
-   if (sys_timebase_id == 0 || time_status != OS_SUCCESS)
+   if (!OS_ObjectIdDefined(sys_timebase_id) || time_status != OS_SUCCESS)
    {
        OS_printf("CFE_PSP: WARNING - Compatibility mode - using local 1Hz Interrupt\n");
        CFE_PSP_SetupLocal1Hz();

--- a/fsw/pc-rtems/src/cfe_psp_start.c
+++ b/fsw/pc-rtems/src/cfe_psp_start.c
@@ -163,7 +163,7 @@ int CFE_PSP_Setup(void)
 
 void CFE_PSP_SetupSystemTimer(void)
 {
-    uint32 SystemTimebase;
+    osal_id_t SystemTimebase;
     int32  Status;
 
     Status = OS_TimeBaseCreate(&SystemTimebase, "cFS-Master", NULL);
@@ -235,7 +235,7 @@ void CFE_PSP_Main(void)
 {
    uint32            reset_type;
    uint32            reset_subtype;
-   uint32            fs_id;
+   osal_id_t         fs_id;
    int32 Status;
 
 

--- a/fsw/shared/src/cfe_psp_exceptionstorage.c
+++ b/fsw/shared/src/cfe_psp_exceptionstorage.c
@@ -155,7 +155,7 @@ uint32 CFE_PSP_Exception_GetCount(void)
  * CFE_PSP_Exception_GetSummary
  * See description in PSP API
  *---------------------------------------------------------------------------*/
-int32 CFE_PSP_Exception_GetSummary(uint32 *ContextLogId, uint32 *TaskId, char *ReasonBuf, uint32 ReasonSize)
+int32 CFE_PSP_Exception_GetSummary(uint32 *ContextLogId, osal_id_t *TaskId, char *ReasonBuf, uint32 ReasonSize)
 {
     const CFE_PSP_Exception_LogData_t* Buffer;
     uint32 NumStored;
@@ -187,7 +187,7 @@ int32 CFE_PSP_Exception_GetSummary(uint32 *ContextLogId, uint32 *TaskId, char *R
         Status = OS_TaskFindIdBySystemData(TaskId, &Buffer->sys_task_id, sizeof(Buffer->sys_task_id));
         if (Status != OS_SUCCESS)
         {
-            *TaskId = 0; /* failed to find a corresponding OSAL ID, so set to zero. */
+            *TaskId = OS_OBJECT_ID_UNDEFINED; /* failed to find a corresponding OSAL ID, so set to zero. */
         }
     }
 

--- a/unit-test-coverage/shared/src/coveragetest-cfe-psp-exceptionstorage.c
+++ b/unit-test-coverage/shared/src/coveragetest-cfe-psp-exceptionstorage.c
@@ -90,8 +90,8 @@ void Test_CFE_PSP_Exception_GetSummary(void)
      */
     char ReasonBuf[128];
     uint32 LogId;
-    uint32 TaskId;
-    uint32 TestId;
+    osal_id_t TaskId;
+    osal_id_t TestId;
 
     /* Nominal - no exceptions pending should return CFE_PSP_NO_EXCEPTION_DATA */
     CFE_PSP_Exception_Reset();
@@ -99,13 +99,13 @@ void Test_CFE_PSP_Exception_GetSummary(void)
 
 
     /* Set up an entry and then run again */
-    TestId = 2857;
+    TestId = OS_ObjectIdFromInteger(2857);
     UT_SetDataBuffer(UT_KEY(OS_TaskFindIdBySystemData), &TestId, sizeof(TestId), false);
     UtAssert_NOT_NULL(CFE_PSP_Exception_GetNextContextBuffer());
     CFE_PSP_Exception_WriteComplete();
     UtAssert_INT32_EQ(CFE_PSP_Exception_GetSummary(&LogId, &TaskId, ReasonBuf, sizeof(ReasonBuf)), CFE_PSP_SUCCESS);
     UtAssert_NONZERO(LogId);
-    UtAssert_UINT32_EQ(TaskId, TestId);
+    UtAssert_UINT32_EQ(OS_ObjectIdToInteger(TaskId), OS_ObjectIdToInteger(TestId));
     UtAssert_ZERO(CFE_PSP_Exception_GetCount());
 
     /* Get an entry with failure to obtain task ID */
@@ -115,7 +115,7 @@ void Test_CFE_PSP_Exception_GetSummary(void)
     UtAssert_INT32_EQ(CFE_PSP_Exception_GetSummary(&LogId, &TaskId, ReasonBuf, sizeof(ReasonBuf)), CFE_PSP_SUCCESS);
     UT_ClearForceFail(UT_KEY(OS_TaskFindIdBySystemData));
     UtAssert_NONZERO(LogId);
-    UtAssert_ZERO(TaskId);
+    UtAssert_ZERO(OS_ObjectIdToInteger(TaskId));
 
     UtAssert_NOT_NULL(CFE_PSP_Exception_GetNextContextBuffer());
     CFE_PSP_Exception_WriteComplete();

--- a/ut-stubs/ut_psp_stubs.c
+++ b/ut-stubs/ut_psp_stubs.c
@@ -699,17 +699,17 @@ uint32 CFE_PSP_Exception_GetCount(void)
      return status;
 }
 
-int32 CFE_PSP_Exception_GetSummary(uint32 *ContextLogId, uint32 *TaskId, char *ReasonBuf, uint32 ReasonSize)
+int32 CFE_PSP_Exception_GetSummary(uint32 *ContextLogId, osal_id_t *TaskId, char *ReasonBuf, uint32 ReasonSize)
 {
     int32 status;
 
     *ContextLogId = 0;
-    *TaskId = 0;
+    *TaskId = OS_OBJECT_ID_UNDEFINED;
     *ReasonBuf = 0;
 
     /* allow the testcase to easily set the taskID output, anything more involved needs a hook */
     status = UT_DEFAULT_IMPL_ARGS(CFE_PSP_Exception_GetSummary, ContextLogId, TaskId, ReasonBuf, ReasonSize);
-    if (status == 0 && *TaskId == 0)
+    if (status == 0 && !OS_ObjectIdDefined(*TaskId))
     {
         UT_Stub_CopyToLocal(UT_KEY(CFE_PSP_Exception_GetSummary), TaskId, sizeof(*TaskId));
     }


### PR DESCRIPTION
**Describe the contribution**
Use the osal_id_t typedef whenever dealing with an OSAL ID value.

Fixes #200 

**Testing performed**
Build and sanity test CFE on all supported platforms

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu 20.04 (native)
RTEMS 4.11.3 / pc686 (QEMU) on Ubuntu 20.04 host
VxWorks 6.9

**Additional context**
This is for consistency with other components and to future proof against type changes.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
