### PR TITLE
Integration Candidate 2020-10-13

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This is a collection of APIs abstracting platform specific functionality to be l
 
 ## Version History
 
+### Development Build: 1.5.0-rc1+dev19
+
+- Use the osal_id_t typedef whenever dealing with an OSAL ID value.
+- Resolves build error regarding redefinition of PPC macros in the coverage test, when building on the actual ppc/vxworks target.
+- See <https://github.com/nasa/PSP/pull/206>
+
 ### Development Build: 1.5.0-rc1+dev14
 
 - Sets the stub config data spacecraft id to historical value 0x42, was 42.
@@ -24,7 +30,7 @@ This is a collection of APIs abstracting platform specific functionality to be l
 
 - Provide a new framework and perform PSP coverage tests. New coverage test executable is built and several files within PSP are targeted.
 - See <https://github.com/nasa/PSP/pull/184>
- 
+
 ### Development Build: 1.4.0+dev71
 
 - Restructure code to make more amicable for rebuilding in a unit test environment. No major changes, primarily just shifting code between locations/headers to support unit testing.
@@ -44,7 +50,7 @@ This is a collection of APIs abstracting platform specific functionality to be l
 ### Development Build: 1.4.12
 
 - Replace 'OS_VolumeTable' with OS_FileSysAddFixedMap() in all PSPs.
-- See <https://github.com/nasa/PSP/pull/166> 
+- See <https://github.com/nasa/PSP/pull/166>
 
 ### Development Build: 1.4.11
 

--- a/fsw/inc/cfe_psp.h
+++ b/fsw/inc/cfe_psp.h
@@ -366,7 +366,7 @@ extern void CFE_PSP_SetDefaultExceptionEnvironment(void);
 
 
 extern uint32 CFE_PSP_Exception_GetCount(void);
-extern int32 CFE_PSP_Exception_GetSummary(uint32 *ContextLogId, uint32 *TaskId, char *ReasonBuf, uint32 ReasonSize);
+extern int32 CFE_PSP_Exception_GetSummary(uint32 *ContextLogId, osal_id_t *TaskId, char *ReasonBuf, uint32 ReasonSize);
 extern int32 CFE_PSP_Exception_CopyContext(uint32 ContextLogId, void *ContextBuf, uint32 ContextSize);
 
 /*

--- a/fsw/mcp750-vxworks/inc/psp_version.h
+++ b/fsw/mcp750-vxworks/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 14
+#define CFE_PSP_IMPL_BUILD_NUMBER 19
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/mcp750-vxworks/src/cfe_psp_start.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_start.c
@@ -96,7 +96,7 @@ void OS_Application_Startup(void)
    int    TicksPerSecond;
    uint32 reset_type;
    uint32 reset_subtype;
-   uint32 fs_id;
+   osal_id_t fs_id;
    char   reset_register;
    int32  Status;
 

--- a/fsw/pc-linux/inc/psp_version.h
+++ b/fsw/pc-linux/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 14
+#define CFE_PSP_IMPL_BUILD_NUMBER 19
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-linux/src/cfe_psp_start.c
+++ b/fsw/pc-linux/src/cfe_psp_start.c
@@ -159,8 +159,8 @@ void OS_Application_Startup(void)
    uint32             reset_type;
    uint32             reset_subtype;
    int32              time_status;
-   uint32             sys_timebase_id;
-   uint32             fs_id;
+   osal_id_t          sys_timebase_id;
+   osal_id_t          fs_id;
    int                opt = 0;
    int                longIndex = 0;
    int32              Status;
@@ -319,7 +319,7 @@ void OS_Application_Startup(void)
         *
         * See below for workaround.
         */
-       sys_timebase_id = 0;
+       sys_timebase_id = OS_OBJECT_ID_UNDEFINED;
    }
 
    /*
@@ -403,7 +403,7 @@ void OS_Application_Startup(void)
    /*
     * Backward compatibility for old OSAL.
     */
-   if (sys_timebase_id == 0 || time_status != OS_SUCCESS)
+   if (!OS_ObjectIdDefined(sys_timebase_id) || time_status != OS_SUCCESS)
    {
        OS_printf("CFE_PSP: WARNING - Compatibility mode - using local 1Hz Interrupt\n");
        CFE_PSP_SetupLocal1Hz();

--- a/fsw/pc-rtems/inc/psp_version.h
+++ b/fsw/pc-rtems/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 14
+#define CFE_PSP_IMPL_BUILD_NUMBER 19
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-rtems/src/cfe_psp_start.c
+++ b/fsw/pc-rtems/src/cfe_psp_start.c
@@ -163,7 +163,7 @@ int CFE_PSP_Setup(void)
 
 void CFE_PSP_SetupSystemTimer(void)
 {
-    uint32 SystemTimebase;
+    osal_id_t SystemTimebase;
     int32  Status;
 
     Status = OS_TimeBaseCreate(&SystemTimebase, "cFS-Master", NULL);
@@ -235,7 +235,7 @@ void CFE_PSP_Main(void)
 {
    uint32            reset_type;
    uint32            reset_subtype;
-   uint32            fs_id;
+   osal_id_t         fs_id;
    int32 Status;
 
 

--- a/fsw/shared/src/cfe_psp_exceptionstorage.c
+++ b/fsw/shared/src/cfe_psp_exceptionstorage.c
@@ -155,7 +155,7 @@ uint32 CFE_PSP_Exception_GetCount(void)
  * CFE_PSP_Exception_GetSummary
  * See description in PSP API
  *---------------------------------------------------------------------------*/
-int32 CFE_PSP_Exception_GetSummary(uint32 *ContextLogId, uint32 *TaskId, char *ReasonBuf, uint32 ReasonSize)
+int32 CFE_PSP_Exception_GetSummary(uint32 *ContextLogId, osal_id_t *TaskId, char *ReasonBuf, uint32 ReasonSize)
 {
     const CFE_PSP_Exception_LogData_t* Buffer;
     uint32 NumStored;
@@ -187,7 +187,7 @@ int32 CFE_PSP_Exception_GetSummary(uint32 *ContextLogId, uint32 *TaskId, char *R
         Status = OS_TaskFindIdBySystemData(TaskId, &Buffer->sys_task_id, sizeof(Buffer->sys_task_id));
         if (Status != OS_SUCCESS)
         {
-            *TaskId = 0; /* failed to find a corresponding OSAL ID, so set to zero. */
+            *TaskId = OS_OBJECT_ID_UNDEFINED; /* failed to find a corresponding OSAL ID, so set to zero. */
         }
     }
 

--- a/unit-test-coverage/shared/src/coveragetest-cfe-psp-exceptionstorage.c
+++ b/unit-test-coverage/shared/src/coveragetest-cfe-psp-exceptionstorage.c
@@ -90,8 +90,8 @@ void Test_CFE_PSP_Exception_GetSummary(void)
      */
     char ReasonBuf[128];
     uint32 LogId;
-    uint32 TaskId;
-    uint32 TestId;
+    osal_id_t TaskId;
+    osal_id_t TestId;
 
     /* Nominal - no exceptions pending should return CFE_PSP_NO_EXCEPTION_DATA */
     CFE_PSP_Exception_Reset();
@@ -99,13 +99,13 @@ void Test_CFE_PSP_Exception_GetSummary(void)
 
 
     /* Set up an entry and then run again */
-    TestId = 2857;
+    TestId = OS_ObjectIdFromInteger(2857);
     UT_SetDataBuffer(UT_KEY(OS_TaskFindIdBySystemData), &TestId, sizeof(TestId), false);
     UtAssert_NOT_NULL(CFE_PSP_Exception_GetNextContextBuffer());
     CFE_PSP_Exception_WriteComplete();
     UtAssert_INT32_EQ(CFE_PSP_Exception_GetSummary(&LogId, &TaskId, ReasonBuf, sizeof(ReasonBuf)), CFE_PSP_SUCCESS);
     UtAssert_NONZERO(LogId);
-    UtAssert_UINT32_EQ(TaskId, TestId);
+    UtAssert_UINT32_EQ(OS_ObjectIdToInteger(TaskId), OS_ObjectIdToInteger(TestId));
     UtAssert_ZERO(CFE_PSP_Exception_GetCount());
 
     /* Get an entry with failure to obtain task ID */
@@ -115,7 +115,7 @@ void Test_CFE_PSP_Exception_GetSummary(void)
     UtAssert_INT32_EQ(CFE_PSP_Exception_GetSummary(&LogId, &TaskId, ReasonBuf, sizeof(ReasonBuf)), CFE_PSP_SUCCESS);
     UT_ClearForceFail(UT_KEY(OS_TaskFindIdBySystemData));
     UtAssert_NONZERO(LogId);
-    UtAssert_ZERO(TaskId);
+    UtAssert_ZERO(OS_ObjectIdToInteger(TaskId));
 
     UtAssert_NOT_NULL(CFE_PSP_Exception_GetNextContextBuffer());
     CFE_PSP_Exception_WriteComplete();

--- a/unit-test-coverage/ut-stubs/inc/PCS_arch_ppc_vxPpcLib.h
+++ b/unit-test-coverage/ut-stubs/inc/PCS_arch_ppc_vxPpcLib.h
@@ -4,6 +4,29 @@
 
 #include <PCS_basetypes.h>
 
+/*
+ * When building the coverage test on an actual VxWorks target,
+ * these symbols are indirectly provided via the system limits.h file.
+ * This results in a redefinition issue if the custom PCS definitions are used.
+ */
+#if defined(_VXWORKS_OS_) && defined(__PPC__)
+
+#define PCS_PPC_MSR_EE      _PPC_MSR_EE
+#define PCS_PPC_MSR_FP      _PPC_MSR_FP
+#define PCS_PPC_MSR_ME      _PPC_MSR_ME
+#define PCS_PPC_MSR_FE0     _PPC_MSR_FE0
+#define PCS_PPC_MSR_FE1     _PPC_MSR_FE1
+#define PCS_PPC_MSR_DR      _PPC_MSR_DR
+
+#define PCS_PPC_FPSCR_VE    _PPC_FPSCR_VE
+#define PCS_PPC_FPSCR_OE    _PPC_FPSCR_OE
+#define PCS_PPC_FPSCR_NI    _PPC_FPSCR_NI
+#define PCS_PPC_FPSCR_ZE    _PPC_FPSCR_ZE
+#define PCS_PPC_FPSCR_XE    _PPC_FPSCR_XE
+#define PCS_PPC_FPSCR_UE    _PPC_FPSCR_UE
+
+#else
+
 /* ----------------------------------------- */
 /* constants normally defined in vxPpcLib.h */
 /* ----------------------------------------- */
@@ -21,6 +44,8 @@
 #define PCS_PPC_FPSCR_ZE    0x2208
 #define PCS_PPC_FPSCR_XE    0x2210
 #define PCS_PPC_FPSCR_UE    0x2220
+
+#endif
 
 
 /* ----------------------------------------- */

--- a/unit-test-coverage/ut-stubs/override_inc/arch/ppc/vxPpcLib.h
+++ b/unit-test-coverage/ut-stubs/override_inc/arch/ppc/vxPpcLib.h
@@ -14,6 +14,13 @@
 
 #include <PCS_arch_ppc_vxPpcLib.h>
 
+/*
+ * When building the coverage test on an actual VxWorks target,
+ * these symbols are indirectly provided via the system limits.h file.
+ * This results in a redefinition issue if the custom PCS definitions are used.
+ */
+#if !defined(_VXWORKS_OS_) || !defined(__PPC__)
+
 /* ----------------------------------------- */
 /* mappings for declarations in vxPpcLib.h */
 /* ----------------------------------------- */
@@ -31,6 +38,7 @@
 #define _PPC_FPSCR_XE   PCS_PPC_FPSCR_XE
 #define _PPC_FPSCR_UE   PCS_PPC_FPSCR_UE
 
+#endif
 
 #define vxTimeBaseGet   PCS_vxTimeBaseGet
 

--- a/ut-stubs/ut_psp_stubs.c
+++ b/ut-stubs/ut_psp_stubs.c
@@ -699,17 +699,17 @@ uint32 CFE_PSP_Exception_GetCount(void)
      return status;
 }
 
-int32 CFE_PSP_Exception_GetSummary(uint32 *ContextLogId, uint32 *TaskId, char *ReasonBuf, uint32 ReasonSize)
+int32 CFE_PSP_Exception_GetSummary(uint32 *ContextLogId, osal_id_t *TaskId, char *ReasonBuf, uint32 ReasonSize)
 {
     int32 status;
 
     *ContextLogId = 0;
-    *TaskId = 0;
+    *TaskId = OS_OBJECT_ID_UNDEFINED;
     *ReasonBuf = 0;
 
     /* allow the testcase to easily set the taskID output, anything more involved needs a hook */
     status = UT_DEFAULT_IMPL_ARGS(CFE_PSP_Exception_GetSummary, ContextLogId, TaskId, ReasonBuf, ReasonSize);
-    if (status == 0 && *TaskId == 0)
+    if (status == 0 && !OS_ObjectIdDefined(*TaskId))
     {
         UT_Stub_CopyToLocal(UT_KEY(CFE_PSP_Exception_GetSummary), TaskId, sizeof(*TaskId));
     }


### PR DESCRIPTION
**Describe the contribution**
Fix #200
Fix #204

**Testing performed**
See Bundle PR - https://github.com/nasa/cFS/pull/147/checks

**Expected behavior changes**

PR #201  - Use the osal_id_t typedef whenever dealing with an OSAL ID value.

PR #205 - Resolves build error regarding redefinition of PPC macros in the coverage test, when building on the actual ppc/vxworks target.

**System(s) tested on**
Bundle CI, Ubuntu 

**Additional context**
Part of https://github.com/nasa/cFS/pull/147

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
@jphickey 
