### PR TITLE
Integration Candidate: 2020-10-20

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ This is a collection of APIs abstracting platform specific functionality to be l
 
 ## Version History
 
+### Development Build: 1.5.0-rc1+dev24
+
+- Improves the module ID lookup when getting the CFE core text segment info. VxWorks PSP should use the real module name, not assume cfe-core.o when getting text segment info
+- See <https://github.com/nasa/PSP/pull/209>
+
 ### Development Build: 1.5.0-rc1+dev19
 
 - Use the osal_id_t typedef whenever dealing with an OSAL ID value.

--- a/fsw/mcp750-vxworks/inc/psp_version.h
+++ b/fsw/mcp750-vxworks/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 19
+#define CFE_PSP_IMPL_BUILD_NUMBER 24
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-linux/inc/psp_version.h
+++ b/fsw/pc-linux/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 19
+#define CFE_PSP_IMPL_BUILD_NUMBER 24
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-rtems/inc/psp_version.h
+++ b/fsw/pc-rtems/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 19
+#define CFE_PSP_IMPL_BUILD_NUMBER 24
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*


### PR DESCRIPTION
**Describe the contribution**
Fix #111 

**Testing performed**
Bundle CI: https://github.com/nasa/cFS/pull/152/checks

**Expected behavior changes**

PR #207 - Improves the module ID lookup when getting the CFE core text segment info. VxWorks PSP should use the real module name, not assume cfe-core.o when getting text segment info

**System(s) tested on**

Ubuntu CI

**Additional context**
Part of <https://github.com/nasa/cFS/pull/152>

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
