### PR TITLE
Fix #199, set kernel task name for OSAL tasks

### DIFF
--- a/fsw/pc-linux/CMakeLists.txt
+++ b/fsw/pc-linux/CMakeLists.txt
@@ -20,3 +20,9 @@ add_library(psp-${CFE_PSP_TARGETNAME}-impl OBJECT
     src/cfe_psp_timer.c
     src/cfe_psp_watchdog.c)
 
+# The _GNU_SOURCE directive is required to call non-posix APIs
+# that are specific to the Linux/glibc environment.
+# Code outside the pc-linux PSP should _not_ depend on this.
+target_compile_definitions(psp-${CFE_SYSTEM_PSPNAME}-impl PRIVATE
+    _GNU_SOURCE
+)


### PR DESCRIPTION
**Describe the contribution**
Use event callback mechanism to invoke `pthread_setname_np()` such that the OS kernel is informed of the OSAL task name.

Fixes #199 

**Testing performed**
Build and sanity test CFE
Check `/proc/<pid>/task/<tid>/comm` and confirm that the correct name is shown for CFE tasks e.g. CFE_EVS, CFE_SB, etc.

**Expected behavior changes**
`/proc` filesystem on Linux has actual task name, instead of all being `core-cpu1`.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
The `pthread_setname_np` API requires `_GNU_SOURCE` to be defined when compiling - this can be local to PSP.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
