### PR TITLE
Integration Candidate: 2020-11-03

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This is a collection of APIs abstracting platform specific functionality to be l
 
 ## Version History
 
+### Development Build: 1.5.0-rc1+dev30
+
+- PR #212 - Use event callback mechanism to invoke pthread_setname_np() such that the OS kernel is informed of the OSAL task name. `/proc` filesystem on Linux now has actual task name, instead of all being core-cpu1. The `pthread_setname_np` API requires `_GNU_SOURCE` to be defined when compiling - this can be local to PSP.
+- Set REVISION to "99" to indicate development version
+- See <https://github.com/nasa/PSP/pull/213>
+
 ### Development Build: 1.5.0-rc1+dev24
 
 - Improves the module ID lookup when getting the CFE core text segment info. VxWorks PSP should use the real module name, not assume cfe-core.o when getting text segment info

--- a/fsw/mcp750-vxworks/inc/psp_version.h
+++ b/fsw/mcp750-vxworks/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 24
+#define CFE_PSP_IMPL_BUILD_NUMBER 30
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/mcp750-vxworks/inc/psp_version.h
+++ b/fsw/mcp750-vxworks/inc/psp_version.h
@@ -38,7 +38,7 @@
 #define CFE_PSP_IMPL_MAJOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
 #define CFE_PSP_IMPL_MINOR_VERSION 4 /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
 #define CFE_PSP_IMPL_REVISION      0 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision number. */
-#define CFE_PSP_IMPL_MISSION_REV   0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
+#define CFE_PSP_IMPL_MISSION_REV   99 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. A value of "99" indicates an unreleased development version.  */
 
 /*
  * Tools to construct version string

--- a/fsw/pc-linux/CMakeLists.txt
+++ b/fsw/pc-linux/CMakeLists.txt
@@ -20,3 +20,9 @@ add_library(psp-${CFE_PSP_TARGETNAME}-impl OBJECT
     src/cfe_psp_timer.c
     src/cfe_psp_watchdog.c)
 
+# The _GNU_SOURCE directive is required to call non-posix APIs
+# that are specific to the Linux/glibc environment.
+# Code outside the pc-linux PSP should _not_ depend on this.
+target_compile_definitions(psp-${CFE_SYSTEM_PSPNAME}-impl PRIVATE
+    _GNU_SOURCE
+)

--- a/fsw/pc-linux/inc/psp_version.h
+++ b/fsw/pc-linux/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 24
+#define CFE_PSP_IMPL_BUILD_NUMBER 30
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-linux/inc/psp_version.h
+++ b/fsw/pc-linux/inc/psp_version.h
@@ -38,7 +38,7 @@
 #define CFE_PSP_IMPL_MAJOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
 #define CFE_PSP_IMPL_MINOR_VERSION 4 /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
 #define CFE_PSP_IMPL_REVISION      0 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision number. */
-#define CFE_PSP_IMPL_MISSION_REV   0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
+#define CFE_PSP_IMPL_MISSION_REV   99 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. A value of "99" indicates an unreleased development version.  */
 
 /*
  * Tools to construct version string

--- a/fsw/pc-linux/src/cfe_psp_start.c
+++ b/fsw/pc-linux/src/cfe_psp_start.c
@@ -79,6 +79,12 @@
 #define CFE_PSP_RESET_NAME_LENGTH 10
 
 /*
+ * Limits for task name length in kernel (fixed by Linux/glibc)
+ * For reference see manpage for "pthread_setname_np".
+ */
+#define CFE_PSP_KERNEL_NAME_LENGTH_MAX  16
+
+/*
 ** Typedefs for this module
 */
 
@@ -141,6 +147,56 @@ static const struct option longOpts[] = {
    { NULL,        no_argument,       NULL,  0 }
 };
 
+/******************************************************************************
+**  Function:  CFE_PSP_OS_EventHandler()
+**
+**  Purpose:
+**    Linux Task creation event handler.
+**    Sets the kernel task name using a glibc-specific (non-posix) function.
+**
+*/
+int32 CFE_PSP_OS_EventHandler(OS_Event_t event, osal_id_t object_id, void *data)
+{
+    switch(event)
+    {
+    case OS_EVENT_RESOURCE_ALLOCATED:
+        /* resource/id is newly allocated but not yet created.  Invoked within locked region. */
+        break;
+    case OS_EVENT_RESOURCE_CREATED:
+        /* resource/id has been fully created/finalized.  Invoked outside locked region. */
+        break;
+    case OS_EVENT_RESOURCE_DELETED:
+        /* resource/id has been deleted.  Invoked outside locked region. */
+        break;
+    case OS_EVENT_TASK_STARTUP:
+    {
+        char taskname[OS_MAX_API_NAME];
+
+        /* New task is starting. Invoked from within the task context. */
+        /* Get the name from OSAL and propagate to the pthread/system layer */
+        if (OS_GetResourceName(object_id, taskname, sizeof(taskname)) == OS_SUCCESS)
+        {
+            /*
+             * glibc/kernel has an internal limit for this name.
+             * If the OSAL name is longer, just truncate it.
+             * Otherwise the name isn't set at all - this assumes the first
+             * chars of the name is better for debug than none of it.
+             */
+            if (strlen(taskname) >= CFE_PSP_KERNEL_NAME_LENGTH_MAX)
+            {
+                taskname[CFE_PSP_KERNEL_NAME_LENGTH_MAX-1] = 0;
+            }
+            pthread_setname_np(pthread_self(), taskname);
+        }
+        break;
+    }
+
+    default:
+        break;
+    }
+
+    return OS_SUCCESS;
+}
 
 /******************************************************************************
 **  Function:  main()
@@ -275,6 +331,8 @@ void OS_Application_Startup(void)
        printf("CFE_PSP: OS_API_Init() failure\n");
        CFE_PSP_Panic(Status);
    }
+
+   OS_RegisterEventHandler(CFE_PSP_OS_EventHandler);
 
    /*
     * Map the PSP shared memory segments

--- a/fsw/pc-linux/src/cfe_psp_start.c
+++ b/fsw/pc-linux/src/cfe_psp_start.c
@@ -157,6 +157,8 @@ static const struct option longOpts[] = {
 */
 int32 CFE_PSP_OS_EventHandler(OS_Event_t event, osal_id_t object_id, void *data)
 {
+    char taskname[OS_MAX_API_NAME];
+
     switch(event)
     {
     case OS_EVENT_RESOURCE_ALLOCATED:
@@ -170,8 +172,6 @@ int32 CFE_PSP_OS_EventHandler(OS_Event_t event, osal_id_t object_id, void *data)
         break;
     case OS_EVENT_TASK_STARTUP:
     {
-        char taskname[OS_MAX_API_NAME];
-
         /* New task is starting. Invoked from within the task context. */
         /* Get the name from OSAL and propagate to the pthread/system layer */
         if (OS_GetResourceName(object_id, taskname, sizeof(taskname)) == OS_SUCCESS)

--- a/fsw/pc-rtems/inc/psp_version.h
+++ b/fsw/pc-rtems/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER   24
+#define CFE_PSP_IMPL_BUILD_NUMBER   30
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-rtems/inc/psp_version.h
+++ b/fsw/pc-rtems/inc/psp_version.h
@@ -19,17 +19,17 @@
 */
 
 /*! @file pc-rtems/inc/psp_version.h
- *  @brief Purpose: 
- *  @details Provide version identifiers for the cFE Platform Support Packages (PSP).   
+ *  @brief Purpose:
+ *  @details Provide version identifiers for the cFE Platform Support Packages (PSP).
  *  See @ref cfsversions for version and build number and description
  */
 #ifndef _psp_version_
 #define _psp_version_
 
 /*
- * Development Build Macro Definitions 
+ * Development Build Macro Definitions
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 24
+#define CFE_PSP_IMPL_BUILD_NUMBER   24
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*
@@ -38,26 +38,27 @@
 #define CFE_PSP_IMPL_MAJOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
 #define CFE_PSP_IMPL_MINOR_VERSION 4 /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
 #define CFE_PSP_IMPL_REVISION      0 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision number. */
-#define CFE_PSP_IMPL_MISSION_REV   0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
+#define CFE_PSP_IMPL_MISSION_REV 99 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. A value of "99" indicates an unreleased development version.  */
 
 /*
  * Tools to construct version string
- */ 
-#define CFE_PSP_IMPL_STR_HELPER(x) #x /*!< @brief Helper function to concatenate strings from integer */ 
-#define CFE_PSP_IMPL_STR(x)        CFE_PSP_IMPL_STR_HELPER(x) /*!< @brief Helper function to concatenate strings from integer */
+ */
+#define CFE_PSP_IMPL_STR_HELPER(x) #x /*!< @brief Helper function to concatenate strings from integer */
+#define CFE_PSP_IMPL_STR(x) \
+    CFE_PSP_IMPL_STR_HELPER(x) /*!< @brief Helper function to concatenate strings from integer */
 
-/*! @brief Development Build Version Number. 
+/*! @brief Development Build Version Number.
  *  @details Baseline git tag + Number of commits since baseline. @n
  *  See @ref cfsversions for format differences between development and release versions.
  */
 #define CFE_PSP_IMPL_VERSION CFE_PSP_IMPL_BUILD_BASELINE CFE_PSP_IMPL_STR(CFE_PSP_IMPL_BUILD_NUMBER)
 
 /*! @brief Development Build Version String.
- *  @details Reports the current development build's baseline, number, and name. Also includes a note about the latest official version. @n
- *  See @ref cfsversions for format differences between development and release versions. 
- */     
-#define CFE_PSP_IMPL_VERSION_STRING                                                                      \
-    " PSP DEVELOPMENT BUILD " CFE_PSP_IMPL_VERSION                /* Codename for current development */ \
-    ", Last Official Release: psp v1.4.0"                        /* For full support please use this version */
+ *  @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
+ * official version. @n See @ref cfsversions for format differences between development and release versions.
+ */
+#define CFE_PSP_IMPL_VERSION_STRING                                                       \
+    " PSP DEVELOPMENT BUILD " CFE_PSP_IMPL_VERSION /* Codename for current development */ \
+    ", Last Official Release: psp v1.4.0"          /* For full support please use this version */
 
-#endif  /* _psp_version_ */
+#endif /* _psp_version_ */


### PR DESCRIPTION
**Describe the contribution**
Fix #199, set kernel task name for OSAL tasks

**Testing performed**
See framework-bundle CI: https://github.com/nasa/cFS/pull/154/checks

**Expected behavior changes**

PR #212 - Use event callback mechanism to invoke pthread_setname_np() such that the OS kernel is informed of the OSAL task name. `/proc` filesystem on Linux now has actual task name, instead of all being core-cpu1. The `pthread_setname_np` API requires `_GNU_SOURCE` to be defined when compiling - this can be local to PSP.

HOTFIX - Move variable declaration in fsw/pc-linux/src/cfe_psp_start.c 

HOTFIX - Set REVISION to "99" to indicate development version in version.h


**System(s) tested on**
Ubuntu on Travis CI

**Additional context**
Part of https://github.com/nasa/cFS/pull/154

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
@jphickey 