### PR TITLE
Fix #214, Refactor UT_SetForceFail to UT_SetDefaultReturnValue

### DIFF
--- a/unit-test-coverage/mcp750-vxworks/src/coveragetest-cfe-psp-start.c
+++ b/unit-test-coverage/mcp750-vxworks/src/coveragetest-cfe-psp-start.c
@@ -76,13 +76,13 @@ void Test_OS_Application_Startup(void)
     UtAssert_INT32_EQ(StartType.StartSubtype, CFE_PSP_RST_SUBTYPE_UNDEFINED_RESET);
 
     /* failure of OS_API_Init */
-    UT_SetForceFail(UT_KEY(OS_API_Init), OS_ERROR);
+    UT_SetDefaultReturnValue(UT_KEY(OS_API_Init), OS_ERROR);
     UT_OS_Application_Startup();
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(PCS_exit)), 1);
     UT_ClearForceFail(UT_KEY(OS_API_Init));
 
     /* failure of OS_FileSysAddFixedMap - an extra OS_printf */
-    UT_SetForceFail(UT_KEY(OS_FileSysAddFixedMap), OS_ERROR);
+    UT_SetDefaultReturnValue(UT_KEY(OS_FileSysAddFixedMap), OS_ERROR);
     UT_OS_Application_Startup();
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(OS_printf)), 9);
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(PCS_SystemMain)), 2);

--- a/unit-test-coverage/shared/src/coveragetest-cfe-psp-exceptionstorage.c
+++ b/unit-test-coverage/shared/src/coveragetest-cfe-psp-exceptionstorage.c
@@ -111,7 +111,7 @@ void Test_CFE_PSP_Exception_GetSummary(void)
     /* Get an entry with failure to obtain task ID */
     UtAssert_NOT_NULL(CFE_PSP_Exception_GetNextContextBuffer());
     CFE_PSP_Exception_WriteComplete();
-    UT_SetForceFail(UT_KEY(OS_TaskFindIdBySystemData), OS_ERROR);
+    UT_SetDefaultReturnValue(UT_KEY(OS_TaskFindIdBySystemData), OS_ERROR);
     UtAssert_INT32_EQ(CFE_PSP_Exception_GetSummary(&LogId, &TaskId, ReasonBuf, sizeof(ReasonBuf)), CFE_PSP_SUCCESS);
     UT_ClearForceFail(UT_KEY(OS_TaskFindIdBySystemData));
     UtAssert_NONZERO(LogId);


### PR DESCRIPTION
Describe the contribution
Fixes #214 by changing UT_SetForceFail to UT_SetDefaultReturnValue

Testing performed
Build and run unit test

Expected behavior changes
No impact to behavior

System(s) tested on
Ubuntu 20.04

Additional context
Dependant on nasa/osal#646

Contributor Info - All information REQUIRED for consideration of pull request
Alex Campbell - NASA/GSFC