### PR TITLE
Fix #217, use size_t in PSP stubs

### DIFF
--- a/unit-test-coverage/ut-stubs/src/libc-stdlib-stubs.c
+++ b/unit-test-coverage/ut-stubs/src/libc-stdlib-stubs.c
@@ -85,7 +85,7 @@ void *PCS_malloc(size_t sz)
     cpuaddr PoolEnd;
     cpuaddr NextBlock;
     size_t NextSize;
-    uint32 PoolSize;
+    size_t PoolSize;
     uint32 CallCnt;
     struct MPOOL_REC *Rec;
 
@@ -156,7 +156,7 @@ void PCS_free(void *ptr)
     int32 Status;
     cpuaddr BlockAddr;
     void *PoolPtr;
-    uint32 PoolSize;
+    size_t PoolSize;
     struct MPOOL_REC *Rec;
 
     /*

--- a/ut-stubs/ut_psp_stubs.c
+++ b/ut-stubs/ut_psp_stubs.c
@@ -232,8 +232,8 @@ int32 CFE_PSP_WriteToCDS(const void *PtrToDataToWrite,
                          uint32 NumBytes)
 {
     uint8 *BufPtr;
-    uint32 CdsSize;
-    uint32 Position;
+    size_t CdsSize;
+    size_t Position;
     int32 status;
 
     status = UT_DEFAULT_IMPL(CFE_PSP_WriteToCDS);
@@ -276,8 +276,8 @@ int32 CFE_PSP_ReadFromCDS(void *PtrToDataToRead,
                           uint32 NumBytes)
 {
     uint8 *BufPtr;
-    uint32 CdsSize;
-    uint32 Position;
+    size_t CdsSize;
+    size_t Position;
     int32 status;
 
     status = UT_DEFAULT_IMPL(CFE_PSP_ReadFromCDS);
@@ -313,14 +313,14 @@ int32 CFE_PSP_ReadFromCDS(void *PtrToDataToRead,
 int32 CFE_PSP_GetCDSSize(uint32 *SizeOfCDS)
 {
     int32 status;
-    void *BufPtr;
-    uint32 Position;
+    size_t TempSize;
 
     status = UT_DEFAULT_IMPL(CFE_PSP_GetCDSSize);
 
     if (status >= 0)
     {
-        UT_GetDataBuffer(UT_KEY(CFE_PSP_GetCDSSize), &BufPtr, SizeOfCDS, &Position);
+        UT_GetDataBuffer(UT_KEY(CFE_PSP_GetCDSSize), NULL, &TempSize, NULL);
+        *SizeOfCDS = TempSize;
     }
 
     return status;
@@ -345,13 +345,17 @@ int32 CFE_PSP_GetCDSSize(uint32 *SizeOfCDS)
 int32 CFE_PSP_GetVolatileDiskMem(cpuaddr *PtrToVolDisk, uint32 *SizeOfVolDisk)
 {
     int32 status;
-    uint32 Position;
+    size_t TempSize;
+    void *TempAddr;
 
     status = UT_DEFAULT_IMPL(CFE_PSP_GetVolatileDiskMem);
 
     if (status >= 0)
     {
-        UT_GetDataBuffer(UT_KEY(CFE_PSP_GetVolatileDiskMem), (void**)PtrToVolDisk, SizeOfVolDisk, &Position);
+        UT_GetDataBuffer(UT_KEY(CFE_PSP_GetVolatileDiskMem), &TempAddr, &TempSize, NULL);
+
+        *PtrToVolDisk = (cpuaddr)TempAddr;
+        *SizeOfVolDisk = TempSize;
     }
 
     return status;
@@ -426,13 +430,17 @@ void CFE_PSP_Get_Timebase(uint32 *Tbu, uint32* Tbl)
 int32 CFE_PSP_GetResetArea(cpuaddr *PtrToResetArea, uint32 *SizeOfResetArea)
 {
     int32 status;
-    uint32 Position;
+    size_t TempSize;
+    void *TempAddr;
 
     status = UT_DEFAULT_IMPL(CFE_PSP_GetResetArea);
 
     if (status >= 0)
     {
-        UT_GetDataBuffer(UT_KEY(CFE_PSP_GetResetArea), (void**)PtrToResetArea, SizeOfResetArea, &Position);
+        UT_GetDataBuffer(UT_KEY(CFE_PSP_GetResetArea), &TempAddr, &TempSize, NULL);
+
+        *PtrToResetArea = (cpuaddr)TempAddr;
+        *SizeOfResetArea = TempSize;
     }
 
     return status;
@@ -553,18 +561,24 @@ int32 CFE_PSP_GetCFETextSegmentInfo(cpuaddr *PtrToCFESegment,
 {
     static uint32 LocalTextSegment;
     int32 status;
-    uint32 Position;
+    void *TempAddr;
+    size_t TempSize;
 
     status = UT_DEFAULT_IMPL(CFE_PSP_GetCFETextSegmentInfo);
 
     if (status >= 0)
     {
-        UT_GetDataBuffer(UT_KEY(CFE_PSP_GetCFETextSegmentInfo), (void**)PtrToCFESegment, SizeOfCFESegment, &Position);
+        UT_GetDataBuffer(UT_KEY(CFE_PSP_GetCFETextSegmentInfo), &TempAddr, &TempSize, NULL);
         if (*PtrToCFESegment == 0)
         {
             /* Backup -- Set the pointer and size to anything */
             *PtrToCFESegment = (cpuaddr)&LocalTextSegment;
             *SizeOfCFESegment = sizeof(LocalTextSegment);
+        }
+        else
+        {
+            *PtrToCFESegment = (cpuaddr)TempAddr;
+            *SizeOfCFESegment = TempSize;
         }
     }
 


### PR DESCRIPTION
**Describe the contribution**
Recent API updates require use of the `size_t` type instead of `uint32`.

This change is required at the same time as nasa/osal#654 is merged (dependency).

Fixes #217 

**Testing performed**
Build and run all unit tests.

**Expected behavior changes**
None.  No FSW changes, only UT stub update here.  

**System(s) tested on**
Ubuntu 20.04

**Additional context**
This is only UT stubs.  FSW requires API change to use `size_t` and that will be a separate issue/PR.  (see #218)

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.