### PR TITLE
psp Integration Candidate: 2020-11-24

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This is a collection of APIs abstracting platform specific functionality to be l
 
 ## Version History
 
+### Development Build: 1.5.0-rc1+dev36
+
+- Rename `UT_SetForceFail` to `UT_SetDefaultReturnValue` since some functions that retain more than 1 value are not necessarily failing.
+- Use of the size_t type instead of uint32 in unit-tests to avoid a compiler type mismatch error on some platforms.
+- See <https://github.com/nasa/PSP/pull/221>
+
 ### Development Build: 1.5.0-rc1+dev30
 
 - PR #212 - Use event callback mechanism to invoke pthread_setname_np() such that the OS kernel is informed of the OSAL task name. `/proc` filesystem on Linux now has actual task name, instead of all being core-cpu1. The `pthread_setname_np` API requires `_GNU_SOURCE` to be defined when compiling - this can be local to PSP.

--- a/fsw/mcp750-vxworks/inc/psp_version.h
+++ b/fsw/mcp750-vxworks/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 30
+#define CFE_PSP_IMPL_BUILD_NUMBER 36
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-linux/inc/psp_version.h
+++ b/fsw/pc-linux/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 30
+#define CFE_PSP_IMPL_BUILD_NUMBER 36
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-rtems/inc/psp_version.h
+++ b/fsw/pc-rtems/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER   30
+#define CFE_PSP_IMPL_BUILD_NUMBER   36
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/unit-test-coverage/mcp750-vxworks/src/coveragetest-cfe-psp-start.c
+++ b/unit-test-coverage/mcp750-vxworks/src/coveragetest-cfe-psp-start.c
@@ -76,13 +76,13 @@ void Test_OS_Application_Startup(void)
     UtAssert_INT32_EQ(StartType.StartSubtype, CFE_PSP_RST_SUBTYPE_UNDEFINED_RESET);
 
     /* failure of OS_API_Init */
-    UT_SetForceFail(UT_KEY(OS_API_Init), OS_ERROR);
+    UT_SetDefaultReturnValue(UT_KEY(OS_API_Init), OS_ERROR);
     UT_OS_Application_Startup();
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(PCS_exit)), 1);
     UT_ClearForceFail(UT_KEY(OS_API_Init));
 
     /* failure of OS_FileSysAddFixedMap - an extra OS_printf */
-    UT_SetForceFail(UT_KEY(OS_FileSysAddFixedMap), OS_ERROR);
+    UT_SetDefaultReturnValue(UT_KEY(OS_FileSysAddFixedMap), OS_ERROR);
     UT_OS_Application_Startup();
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(OS_printf)), 9);
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(PCS_SystemMain)), 2);

--- a/unit-test-coverage/shared/src/coveragetest-cfe-psp-exceptionstorage.c
+++ b/unit-test-coverage/shared/src/coveragetest-cfe-psp-exceptionstorage.c
@@ -111,7 +111,7 @@ void Test_CFE_PSP_Exception_GetSummary(void)
     /* Get an entry with failure to obtain task ID */
     UtAssert_NOT_NULL(CFE_PSP_Exception_GetNextContextBuffer());
     CFE_PSP_Exception_WriteComplete();
-    UT_SetForceFail(UT_KEY(OS_TaskFindIdBySystemData), OS_ERROR);
+    UT_SetDefaultReturnValue(UT_KEY(OS_TaskFindIdBySystemData), OS_ERROR);
     UtAssert_INT32_EQ(CFE_PSP_Exception_GetSummary(&LogId, &TaskId, ReasonBuf, sizeof(ReasonBuf)), CFE_PSP_SUCCESS);
     UT_ClearForceFail(UT_KEY(OS_TaskFindIdBySystemData));
     UtAssert_NONZERO(LogId);

--- a/unit-test-coverage/ut-stubs/src/libc-stdlib-stubs.c
+++ b/unit-test-coverage/ut-stubs/src/libc-stdlib-stubs.c
@@ -85,7 +85,7 @@ void *PCS_malloc(size_t sz)
     cpuaddr PoolEnd;
     cpuaddr NextBlock;
     size_t NextSize;
-    uint32 PoolSize;
+    size_t PoolSize;
     uint32 CallCnt;
     struct MPOOL_REC *Rec;
 
@@ -156,7 +156,7 @@ void PCS_free(void *ptr)
     int32 Status;
     cpuaddr BlockAddr;
     void *PoolPtr;
-    uint32 PoolSize;
+    size_t PoolSize;
     struct MPOOL_REC *Rec;
 
     /*

--- a/ut-stubs/ut_psp_stubs.c
+++ b/ut-stubs/ut_psp_stubs.c
@@ -232,8 +232,8 @@ int32 CFE_PSP_WriteToCDS(const void *PtrToDataToWrite,
                          uint32 NumBytes)
 {
     uint8 *BufPtr;
-    uint32 CdsSize;
-    uint32 Position;
+    size_t CdsSize;
+    size_t Position;
     int32 status;
 
     status = UT_DEFAULT_IMPL(CFE_PSP_WriteToCDS);
@@ -276,8 +276,8 @@ int32 CFE_PSP_ReadFromCDS(void *PtrToDataToRead,
                           uint32 NumBytes)
 {
     uint8 *BufPtr;
-    uint32 CdsSize;
-    uint32 Position;
+    size_t CdsSize;
+    size_t Position;
     int32 status;
 
     status = UT_DEFAULT_IMPL(CFE_PSP_ReadFromCDS);
@@ -313,14 +313,14 @@ int32 CFE_PSP_ReadFromCDS(void *PtrToDataToRead,
 int32 CFE_PSP_GetCDSSize(uint32 *SizeOfCDS)
 {
     int32 status;
-    void *BufPtr;
-    uint32 Position;
+    size_t TempSize;
 
     status = UT_DEFAULT_IMPL(CFE_PSP_GetCDSSize);
 
     if (status >= 0)
     {
-        UT_GetDataBuffer(UT_KEY(CFE_PSP_GetCDSSize), &BufPtr, SizeOfCDS, &Position);
+        UT_GetDataBuffer(UT_KEY(CFE_PSP_GetCDSSize), NULL, &TempSize, NULL);
+        *SizeOfCDS = TempSize;
     }
 
     return status;
@@ -345,13 +345,17 @@ int32 CFE_PSP_GetCDSSize(uint32 *SizeOfCDS)
 int32 CFE_PSP_GetVolatileDiskMem(cpuaddr *PtrToVolDisk, uint32 *SizeOfVolDisk)
 {
     int32 status;
-    uint32 Position;
+    size_t TempSize;
+    void *TempAddr;
 
     status = UT_DEFAULT_IMPL(CFE_PSP_GetVolatileDiskMem);
 
     if (status >= 0)
     {
-        UT_GetDataBuffer(UT_KEY(CFE_PSP_GetVolatileDiskMem), (void**)PtrToVolDisk, SizeOfVolDisk, &Position);
+        UT_GetDataBuffer(UT_KEY(CFE_PSP_GetVolatileDiskMem), &TempAddr, &TempSize, NULL);
+
+        *PtrToVolDisk = (cpuaddr)TempAddr;
+        *SizeOfVolDisk = TempSize;
     }
 
     return status;
@@ -426,13 +430,17 @@ void CFE_PSP_Get_Timebase(uint32 *Tbu, uint32* Tbl)
 int32 CFE_PSP_GetResetArea(cpuaddr *PtrToResetArea, uint32 *SizeOfResetArea)
 {
     int32 status;
-    uint32 Position;
+    size_t TempSize;
+    void *TempAddr;
 
     status = UT_DEFAULT_IMPL(CFE_PSP_GetResetArea);
 
     if (status >= 0)
     {
-        UT_GetDataBuffer(UT_KEY(CFE_PSP_GetResetArea), (void**)PtrToResetArea, SizeOfResetArea, &Position);
+        UT_GetDataBuffer(UT_KEY(CFE_PSP_GetResetArea), &TempAddr, &TempSize, NULL);
+
+        *PtrToResetArea = (cpuaddr)TempAddr;
+        *SizeOfResetArea = TempSize;
     }
 
     return status;
@@ -553,18 +561,24 @@ int32 CFE_PSP_GetCFETextSegmentInfo(cpuaddr *PtrToCFESegment,
 {
     static uint32 LocalTextSegment;
     int32 status;
-    uint32 Position;
+    void *TempAddr;
+    size_t TempSize;
 
     status = UT_DEFAULT_IMPL(CFE_PSP_GetCFETextSegmentInfo);
 
     if (status >= 0)
     {
-        UT_GetDataBuffer(UT_KEY(CFE_PSP_GetCFETextSegmentInfo), (void**)PtrToCFESegment, SizeOfCFESegment, &Position);
+        UT_GetDataBuffer(UT_KEY(CFE_PSP_GetCFETextSegmentInfo), &TempAddr, &TempSize, NULL);
         if (*PtrToCFESegment == 0)
         {
             /* Backup -- Set the pointer and size to anything */
             *PtrToCFESegment = (cpuaddr)&LocalTextSegment;
             *SizeOfCFESegment = sizeof(LocalTextSegment);
+        }
+        else
+        {
+            *PtrToCFESegment = (cpuaddr)TempAddr;
+            *SizeOfCFESegment = TempSize;
         }
     }
 


### PR DESCRIPTION
**Describe the contribution**
Fix #214, Refactoring UT_SetForceFail to UT_SetDefaultReturnValue
Fix #217, use size_t in PSP stubs

**Testing performed**
See events for "github actions test" at <https://github.com/astrogeco/cFS/actions>

**Expected behavior changes**
PR #215 - Rename `UT_SetForceFail` to `UT_SetDefaultReturnValue` since some functions that retain more than 1 value are not necessarily failing.

PR #219 - Use of the size_t type instead of uint32 in unit-tests to avoid a compiler type mismatch error on some platforms. 

**System(s) tested on**
Ubuntu 18.04

**Additional context**
Part of <https://github.com/nasa/cFS/pull/158>

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
@zanzaben 
@jphickey 