### PR TITLE
Fix #222, Remove obsolete OS_TaskRegister comment

### DIFF
--- a/fsw/mcp750-vxworks/src/cfe_psp_exception.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_exception.c
@@ -169,7 +169,6 @@ void CFE_PSP_ExceptionHook (TASK_ID task_id, int vector, void* vpEsf )
 **
 **   Notes: The exception environment is local to each task Therefore this must be
 **          called for each task that that wants to do floating point and catch exceptions
-**          Currently, this is automatically called from OS_TaskRegister for every task
 */
 void CFE_PSP_SetDefaultExceptionEnvironment(void)
 {

--- a/fsw/pc-linux/src/cfe_psp_exception.c
+++ b/fsw/pc-linux/src/cfe_psp_exception.c
@@ -264,7 +264,6 @@ void CFE_PSP_AttachExceptions(void)
 **
 **   Notes: The exception environment is local to each task Therefore this must be
 **          called for each task that that wants to do floating point and catch exceptions
-**          Currently, this is automaticall called from OS_TaskRegister for every task
 */
 
 void CFE_PSP_SetDefaultExceptionEnvironment(void)

--- a/fsw/pc-rtems/src/cfe_psp_exception.c
+++ b/fsw/pc-rtems/src/cfe_psp_exception.c
@@ -95,7 +95,6 @@ int32 CFE_PSP_ExceptionGetSummary_Impl(const CFE_PSP_Exception_LogData_t* Buffer
 **
 **   Notes: The exception environment is local to each task Therefore this must be
 **          called for each task that that wants to do floating point and catch exceptions
-**          Currently, this is automaticall called from OS_TaskRegister for every task
 */
 void CFE_PSP_SetDefaultExceptionEnvironment(void)
 {


### PR DESCRIPTION
**Describe the contribution**
Fix #222, remove obsolete OS_TaskRegister comment (really only called for ES tasks... remaining comment is what is important)

**Testing performed**
None, comment only

**Expected behavior changes**
None

**System(s) tested on**
N/A

**Additional context**
nasa/osal#255

**Third party code**
None.

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC