### PR TITLE
PSP Integration Candidate: 2020-12-08

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ This is a collection of APIs abstracting platform specific functionality to be l
 
 ## Version History
 
+### Development Build: 1.5.0-rc1+dev42
+
+- Updates the Readme for RTEMS and adds `README_RTEMS_5.txt`. The changes include removing references to the CEXP module loader, and describing the development environment setup for RTEMS 5.  
+- Remove obsolete OS_TaskRegister comment.  
+- See <https://github.com/nasa/PSP/pull/226>
+
+
 ### Development Build: 1.5.0-rc1+dev36
 
 - Rename `UT_SetForceFail` to `UT_SetDefaultReturnValue` since some functions that retain more than 1 value are not necessarily failing.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This is a collection of APIs abstracting platform specific functionality to be l
 
 ## Version History
 
+### Development Build: 1.5.0-rc1+dev36
+
+- Rename `UT_SetForceFail` to `UT_SetDefaultReturnValue` since some functions that retain more than 1 value are not necessarily failing.
+- Use of the size_t type instead of uint32 in unit-tests to avoid a compiler type mismatch error on some platforms.
+- See <https://github.com/nasa/PSP/pull/221>
+
 ### Development Build: 1.5.0-rc1+dev30
 
 - PR #212 - Use event callback mechanism to invoke pthread_setname_np() such that the OS kernel is informed of the OSAL task name. `/proc` filesystem on Linux now has actual task name, instead of all being core-cpu1. The `pthread_setname_np` API requires `_GNU_SOURCE` to be defined when compiling - this can be local to PSP.

--- a/fsw/mcp750-vxworks/inc/psp_version.h
+++ b/fsw/mcp750-vxworks/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 30
+#define CFE_PSP_IMPL_BUILD_NUMBER 36
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/mcp750-vxworks/inc/psp_version.h
+++ b/fsw/mcp750-vxworks/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 36
+#define CFE_PSP_IMPL_BUILD_NUMBER 42
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/mcp750-vxworks/src/cfe_psp_exception.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_exception.c
@@ -169,7 +169,6 @@ void CFE_PSP_ExceptionHook (TASK_ID task_id, int vector, void* vpEsf )
 **
 **   Notes: The exception environment is local to each task Therefore this must be
 **          called for each task that that wants to do floating point and catch exceptions
-**          Currently, this is automatically called from OS_TaskRegister for every task
 */
 void CFE_PSP_SetDefaultExceptionEnvironment(void)
 {

--- a/fsw/pc-linux/inc/psp_version.h
+++ b/fsw/pc-linux/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 30
+#define CFE_PSP_IMPL_BUILD_NUMBER 36
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-linux/inc/psp_version.h
+++ b/fsw/pc-linux/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 36
+#define CFE_PSP_IMPL_BUILD_NUMBER 42
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-linux/src/cfe_psp_exception.c
+++ b/fsw/pc-linux/src/cfe_psp_exception.c
@@ -264,7 +264,6 @@ void CFE_PSP_AttachExceptions(void)
 **
 **   Notes: The exception environment is local to each task Therefore this must be
 **          called for each task that that wants to do floating point and catch exceptions
-**          Currently, this is automaticall called from OS_TaskRegister for every task
 */
 
 void CFE_PSP_SetDefaultExceptionEnvironment(void)

--- a/fsw/pc-rtems/inc/psp_version.h
+++ b/fsw/pc-rtems/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER   30
+#define CFE_PSP_IMPL_BUILD_NUMBER   36
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-rtems/inc/psp_version.h
+++ b/fsw/pc-rtems/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER   36
+#define CFE_PSP_IMPL_BUILD_NUMBER   42
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-rtems/src/cfe_psp_exception.c
+++ b/fsw/pc-rtems/src/cfe_psp_exception.c
@@ -95,7 +95,6 @@ int32 CFE_PSP_ExceptionGetSummary_Impl(const CFE_PSP_Exception_LogData_t* Buffer
 **
 **   Notes: The exception environment is local to each task Therefore this must be
 **          called for each task that that wants to do floating point and catch exceptions
-**          Currently, this is automaticall called from OS_TaskRegister for every task
 */
 void CFE_PSP_SetDefaultExceptionEnvironment(void)
 {

--- a/unit-test-coverage/mcp750-vxworks/src/coveragetest-cfe-psp-start.c
+++ b/unit-test-coverage/mcp750-vxworks/src/coveragetest-cfe-psp-start.c
@@ -76,13 +76,13 @@ void Test_OS_Application_Startup(void)
     UtAssert_INT32_EQ(StartType.StartSubtype, CFE_PSP_RST_SUBTYPE_UNDEFINED_RESET);
 
     /* failure of OS_API_Init */
-    UT_SetForceFail(UT_KEY(OS_API_Init), OS_ERROR);
+    UT_SetDefaultReturnValue(UT_KEY(OS_API_Init), OS_ERROR);
     UT_OS_Application_Startup();
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(PCS_exit)), 1);
     UT_ClearForceFail(UT_KEY(OS_API_Init));
 
     /* failure of OS_FileSysAddFixedMap - an extra OS_printf */
-    UT_SetForceFail(UT_KEY(OS_FileSysAddFixedMap), OS_ERROR);
+    UT_SetDefaultReturnValue(UT_KEY(OS_FileSysAddFixedMap), OS_ERROR);
     UT_OS_Application_Startup();
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(OS_printf)), 9);
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(PCS_SystemMain)), 2);

--- a/unit-test-coverage/shared/src/coveragetest-cfe-psp-exceptionstorage.c
+++ b/unit-test-coverage/shared/src/coveragetest-cfe-psp-exceptionstorage.c
@@ -111,7 +111,7 @@ void Test_CFE_PSP_Exception_GetSummary(void)
     /* Get an entry with failure to obtain task ID */
     UtAssert_NOT_NULL(CFE_PSP_Exception_GetNextContextBuffer());
     CFE_PSP_Exception_WriteComplete();
-    UT_SetForceFail(UT_KEY(OS_TaskFindIdBySystemData), OS_ERROR);
+    UT_SetDefaultReturnValue(UT_KEY(OS_TaskFindIdBySystemData), OS_ERROR);
     UtAssert_INT32_EQ(CFE_PSP_Exception_GetSummary(&LogId, &TaskId, ReasonBuf, sizeof(ReasonBuf)), CFE_PSP_SUCCESS);
     UT_ClearForceFail(UT_KEY(OS_TaskFindIdBySystemData));
     UtAssert_NONZERO(LogId);


### PR DESCRIPTION
**Describe the contribution**

Fix #197, Updated readme file for pc-rtems PSP and added a new readm…
Fix #222, Remove obsolete OS_TaskRegister comment

**Testing performed**
See https://github.com/nasa/cFS/pull/160/checks

**Expected behavior changes**

PR #220 - Updates the Readme for RTEMS and adds `README_RTEMS_5.txt`. The changes include removing references to the CEXP module loader, and describing the development environment setup for RTEMS 5.

PR #223 - Remove obsolete OS_TaskRegister comment

**System(s) tested on**
Ubuntu 18.04

**Additional context**
Part of https://github.com/nasa/cFS/pull/160

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
@acudmore 
@skliper 
