### PR TITLE
Fix #228, Refactor UT_ClearForceFail to UT_ClearDefaultReturnValue

### DIFF
--- a/unit-test-coverage/mcp750-vxworks/src/coveragetest-cfe-psp-start.c
+++ b/unit-test-coverage/mcp750-vxworks/src/coveragetest-cfe-psp-start.c
@@ -79,14 +79,14 @@ void Test_OS_Application_Startup(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_API_Init), OS_ERROR);
     UT_OS_Application_Startup();
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(PCS_exit)), 1);
-    UT_ClearForceFail(UT_KEY(OS_API_Init));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_API_Init));
 
     /* failure of OS_FileSysAddFixedMap - an extra OS_printf */
     UT_SetDefaultReturnValue(UT_KEY(OS_FileSysAddFixedMap), OS_ERROR);
     UT_OS_Application_Startup();
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(OS_printf)), 9);
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(PCS_SystemMain)), 2);
-    UT_ClearForceFail(UT_KEY(OS_FileSysAddFixedMap));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_FileSysAddFixedMap));
 
     /* coverage for each of the reset types */
     *PCS_SYS_REG_BLRR = PCS_SYS_REG_BLRR_PWRON;

--- a/unit-test-coverage/shared/src/coveragetest-cfe-psp-exceptionstorage.c
+++ b/unit-test-coverage/shared/src/coveragetest-cfe-psp-exceptionstorage.c
@@ -113,7 +113,7 @@ void Test_CFE_PSP_Exception_GetSummary(void)
     CFE_PSP_Exception_WriteComplete();
     UT_SetDefaultReturnValue(UT_KEY(OS_TaskFindIdBySystemData), OS_ERROR);
     UtAssert_INT32_EQ(CFE_PSP_Exception_GetSummary(&LogId, &TaskId, ReasonBuf, sizeof(ReasonBuf)), CFE_PSP_SUCCESS);
-    UT_ClearForceFail(UT_KEY(OS_TaskFindIdBySystemData));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_TaskFindIdBySystemData));
     UtAssert_NONZERO(LogId);
     UtAssert_ZERO(OS_ObjectIdToInteger(TaskId));
 


### PR DESCRIPTION
**Describe the contribution**
Fixes #228
Rename UT_ClearForceFail to UT_ClearDefaultValue

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Dependant on nasa/osal#725

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC
