### PR TITLE
Fix #227, Use OSAL time conversion/access methods

### DIFF
--- a/fsw/pc-linux/src/cfe_psp_timer.c
+++ b/fsw/pc-linux/src/cfe_psp_timer.c
@@ -164,8 +164,8 @@ void CFE_PSP_Get_Timebase(uint32 *Tbu, uint32* Tbl)
    OS_time_t        time;
 
    OS_GetLocalTime(&time);
-   *Tbu = time.seconds;
-   *Tbl = time.microsecs;
+   *Tbu = OS_TimeGetTotalSeconds(time);
+   *Tbl = OS_TimeGetMicrosecondsPart(time);
 }
 
 /******************************************************************************

--- a/fsw/pc-rtems/src/cfe_psp_timer.c
+++ b/fsw/pc-rtems/src/cfe_psp_timer.c
@@ -158,8 +158,8 @@ void CFE_PSP_Get_Timebase(uint32 *Tbu, uint32* Tbl)
    OS_time_t        time;
 
    OS_GetLocalTime(&time);
-   *Tbu = time.seconds;
-   *Tbl = time.microsecs;
+   *Tbu = OS_TimeGetTotalSeconds(time);
+   *Tbl = OS_TimeGetMicrosecondsPart(time);
 }
 
 /******************************************************************************
@@ -180,4 +180,3 @@ uint32 CFE_PSP_Get_Dec(void)
 {
    return(0);
 }
-

--- a/ut-stubs/ut_psp_stubs.c
+++ b/ut-stubs/ut_psp_stubs.c
@@ -200,8 +200,7 @@ void CFE_PSP_GetTime(OS_time_t *LocalTime)
     {
         if (UT_Stub_CopyToLocal(UT_KEY(CFE_PSP_GetTime), (uint8*)LocalTime, sizeof(*LocalTime)) < sizeof(*LocalTime))
         {
-            LocalTime->seconds = 100;
-            LocalTime->microsecs = 200;
+            *LocalTime = OS_TimeAssembleFromNanoseconds(100,200000);
         }
     }
 }


### PR DESCRIPTION
**Describe the contribution**

Instead of accessing `OS_time_t` member values directly, use the OSAL-provided conversion and access methods.  This provides
independence/abstraction from the specific `OS_time_t` definition and allows OSAL to transition to a 64 bit value.

Fixes #227 

**Testing performed**
Build and run tests, sanity check CFE

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu 20.04 (native)
RTEMS 4.11.3 + pc686 (qemu)

**Additional context**
Also adjusts the conversion factors within in `CFE_PSP_GetTime()` to get a more precise result on VxWorks.  Linux/RTEMS are just pass-thru to OSAL anyway.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
