### PR TITLE
Fix #232, Re-add automated static code analysis 

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,49 @@
+name: Static Analysis
+
+# Run this workflow every time a new commit pushed to your repository
+on: [push, pull_request]
+
+jobs:
+
+  static-analysis:
+    name: Run cppcheck
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        cppcheck: [all, psp]
+
+    steps:
+
+      - name: Install cppcheck
+        run: sudo apt-get install cppcheck -y
+
+        # Checks out a copy of the cfs bundle
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Run bundle cppcheck
+        if: ${{matrix.cppcheck =='all'}}
+        run: cppcheck --force --inline-suppr --quiet . 2> ${{matrix.cppcheck}}_cppcheck_err.txt
+
+      - name: psp strict cppcheck
+        if: ${{matrix.cppcheck =='psp'}}
+        run: |
+          cppcheck --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./fsw 2> ./${{matrix.cppcheck}}_cppcheck_err.txt
+
+      - name: Archive Static Analysis Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{matrix.cppcheck}}-cppcheck-err
+          path: ./*cppcheck_err.txt
+
+      - name: Check for errors
+        run: |
+          if [[ -s ${{matrix.cppcheck}}_cppcheck_err.txt ]];
+          then
+            cat ${{matrix.cppcheck}}_cppcheck_err.txt
+            exit -1
+          fi


### PR DESCRIPTION
**Describe the contribution**
Fix #232

**Testing performed**
See action runs in fork: <https://github.com/astrogeco/psp/actions>

**Expected behavior changes**
Static analysis workflow runs on pull requests and push.

Workflow saves log file as an artifact for analysis.

**System(s) tested on**
n/a

**Additional context**
n/a

**Third party code**
n/a