### PR TITLE
Fix #126, Refactor CFE_PSP_ModuleType_t enum

### DIFF
--- a/fsw/shared/inc/cfe_psp_module.h
+++ b/fsw/shared/inc/cfe_psp_module.h
@@ -36,10 +36,8 @@
 typedef enum
 {
     CFE_PSP_MODULE_TYPE_INVALID = 0,
-    CFE_PSP_MODULE_TYPE_VALID_RANGE  = 1000,
-    CFE_PSP_MODULE_TYPE_SIMPLE,
+    CFE_PSP_MODULE_TYPE_SIMPLE
     /* May be extended in the future */
-    CFE_PSP_MODULE_TYPE_MAX
 } CFE_PSP_ModuleType_t;
 
 /**

--- a/fsw/shared/src/cfe_psp_module.c
+++ b/fsw/shared/src/cfe_psp_module.c
@@ -65,8 +65,7 @@ void CFE_PSP_ModuleInit(void)
         while(Entry->Name != NULL)
         {
             ApiPtr = (CFE_PSP_ModuleApi_t *)Entry->Api;
-            if ((uint32)ApiPtr->ModuleType > CFE_PSP_MODULE_TYPE_VALID_RANGE &&
-                    (uint32)ApiPtr->ModuleType < CFE_PSP_MODULE_TYPE_MAX &&
+            if ((uint32)ApiPtr->ModuleType == CFE_PSP_MODULE_TYPE_SIMPLE &&
                     ApiPtr->Init != NULL)
             {
                 (*ApiPtr->Init)(CFE_PSP_MODULE_BASE | CFE_PSP_ModuleCount);


### PR DESCRIPTION
**Describe the contribution**
Fix #126 - Avoids irregular enum warning

**Testing performed**
Build bundle and unit test (passed)

**Expected behavior changes**
None other than eliminates static analysis warning

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC