### PR TITLE
psp Integration Candidate: 2021-01-13

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ This is a collection of APIs abstracting platform specific functionality to be l
 
 ## Version History
 
+### Development Build: 1.5.0-rc1+dev50
+
+-  Instead of accessing `OS_time_t` member values directly, use the OSAL-provided conversion and access methods. This provides independence and abstraction from the specific `OS_time_t` definition and allows OSAL to transition to a 64 bit value.
+- See <https://github.com/nasa/psp/pull/240>
+
 ### Development Build: 1.5.0-rc1+dev46
 
 - Add cppcheck GitHub Actions workflow file

--- a/fsw/mcp750-vxworks/inc/psp_version.h
+++ b/fsw/mcp750-vxworks/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 46
+#define CFE_PSP_IMPL_BUILD_NUMBER 50
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-linux/inc/psp_version.h
+++ b/fsw/pc-linux/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 46
+#define CFE_PSP_IMPL_BUILD_NUMBER 50
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-linux/src/cfe_psp_timer.c
+++ b/fsw/pc-linux/src/cfe_psp_timer.c
@@ -164,8 +164,8 @@ void CFE_PSP_Get_Timebase(uint32 *Tbu, uint32* Tbl)
    OS_time_t        time;
 
    OS_GetLocalTime(&time);
-   *Tbu = time.seconds;
-   *Tbl = time.microsecs;
+   *Tbu = OS_TimeGetTotalSeconds(time);
+   *Tbl = OS_TimeGetMicrosecondsPart(time);
 }
 
 /******************************************************************************

--- a/fsw/pc-rtems/inc/psp_version.h
+++ b/fsw/pc-rtems/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER   46
+#define CFE_PSP_IMPL_BUILD_NUMBER   50
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-rtems/src/cfe_psp_timer.c
+++ b/fsw/pc-rtems/src/cfe_psp_timer.c
@@ -158,8 +158,8 @@ void CFE_PSP_Get_Timebase(uint32 *Tbu, uint32* Tbl)
    OS_time_t        time;
 
    OS_GetLocalTime(&time);
-   *Tbu = time.seconds;
-   *Tbl = time.microsecs;
+   *Tbu = OS_TimeGetTotalSeconds(time);
+   *Tbl = OS_TimeGetMicrosecondsPart(time);
 }
 
 /******************************************************************************
@@ -180,4 +180,3 @@ uint32 CFE_PSP_Get_Dec(void)
 {
    return(0);
 }
-

--- a/ut-stubs/ut_psp_stubs.c
+++ b/ut-stubs/ut_psp_stubs.c
@@ -200,8 +200,7 @@ void CFE_PSP_GetTime(OS_time_t *LocalTime)
     {
         if (UT_Stub_CopyToLocal(UT_KEY(CFE_PSP_GetTime), (uint8*)LocalTime, sizeof(*LocalTime)) < sizeof(*LocalTime))
         {
-            LocalTime->seconds = 100;
-            LocalTime->microsecs = 200;
+            *LocalTime = OS_TimeAssembleFromNanoseconds(100,200000);
         }
     }
 }


### PR DESCRIPTION
**Describe the contribution**

Fix #227, Use OSAL time conversion/access methods

**Testing performed**
See <https://github.com/nasa/cFS/pull/174/checks>

**Expected behavior changes**

PR #231 - Instead of accessing `OS_time_t` member values directly, use the OSAL-provided conversion and access methods. This provides independence and abstraction from the specific `OS_time_t` definition and allows OSAL to transition to a 64 bit value.

**System(s) tested on**
Ubuntu 18.04

**Additional context**
Part of <https://github.com/nasa/cFS/pull/174>

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
@jphickey 