### PR TITLE
Fix #241, Add missing +dev to development version string

### DIFF
--- a/fsw/inc/cfe_psp.h
+++ b/fsw/inc/cfe_psp.h
@@ -151,7 +151,7 @@
 #define CFE_PSP_MINOR_VERSION (GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.MinorVersion)
 #define CFE_PSP_REVISION      (GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.Revision)
 #define CFE_PSP_MISSION_REV   (GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.MissionRev)
-#define CFE_PSP_VERSION       (GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.Version)
+#define CFE_PSP_VERSION       (GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.VersionString)
 
 /*
 ** Type Definitions

--- a/fsw/inc/cfe_psp_configdata.h
+++ b/fsw/inc/cfe_psp_configdata.h
@@ -43,7 +43,7 @@ typedef const struct
     uint8 MinorVersion;
     uint8 Revision;
     uint8 MissionRev;
-    char  Version[16];
+    char  VersionString[32];
 } CFE_PSP_VersionInfo_t;
 
 /**

--- a/fsw/mcp750-vxworks/inc/psp_version.h
+++ b/fsw/mcp750-vxworks/inc/psp_version.h
@@ -49,13 +49,13 @@
 #define CFE_PSP_IMPL_STR(x) \
     CFE_PSP_IMPL_STR_HELPER(x) /*!< @brief Helper function to concatenate strings from integer */
 
-/*! @brief Development Build Version Number.
+/*! @brief DEVELOPMENT Build Version Number.
  *  @details Baseline git tag + Number of commits since baseline. @n
  *  See @ref cfsversions for format differences between development and release versions.
  */
-#define CFE_PSP_IMPL_VERSION CFE_PSP_IMPL_BUILD_BASELINE CFE_PSP_IMPL_STR(CFE_PSP_IMPL_BUILD_NUMBER)
+#define CFE_PSP_IMPL_VERSION CFE_PSP_IMPL_BUILD_BASELINE "+dev" CFE_PSP_IMPL_STR(CFE_PSP_IMPL_BUILD_NUMBER)
 
-/*! @brief Development Build Version String.
+/*! @brief DEVELOPMENT Build Version String.
  *  @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
  * official version. @n See @ref cfsversions for format differences between development and release versions.
  */

--- a/fsw/pc-linux/inc/psp_version.h
+++ b/fsw/pc-linux/inc/psp_version.h
@@ -49,13 +49,13 @@
 #define CFE_PSP_IMPL_STR(x) \
     CFE_PSP_IMPL_STR_HELPER(x) /*!< @brief Helper function to concatenate strings from integer */
 
-/*! @brief Development Build Version Number.
+/*! @brief DEVELOPMENT Build Version Number.
  *  @details Baseline git tag + Number of commits since baseline. @n
  *  See @ref cfsversions for format differences between development and release versions.
  */
-#define CFE_PSP_IMPL_VERSION CFE_PSP_IMPL_BUILD_BASELINE CFE_PSP_IMPL_STR(CFE_PSP_IMPL_BUILD_NUMBER)
+#define CFE_PSP_IMPL_VERSION CFE_PSP_IMPL_BUILD_BASELINE "+dev" CFE_PSP_IMPL_STR(CFE_PSP_IMPL_BUILD_NUMBER)
 
-/*! @brief Development Build Version String.
+/*! @brief DEVELOPMENT Build Version String.
  *  @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
  * official version. @n See @ref cfsversions for format differences between development and release versions.
  */

--- a/fsw/pc-rtems/inc/psp_version.h
+++ b/fsw/pc-rtems/inc/psp_version.h
@@ -49,13 +49,13 @@
 #define CFE_PSP_IMPL_STR(x) \
     CFE_PSP_IMPL_STR_HELPER(x) /*!< @brief Helper function to concatenate strings from integer */
 
-/*! @brief Development Build Version Number.
+/*! @brief DEVELOPMENT Build Version Number.
  *  @details Baseline git tag + Number of commits since baseline. @n
  *  See @ref cfsversions for format differences between development and release versions.
  */
-#define CFE_PSP_IMPL_VERSION CFE_PSP_IMPL_BUILD_BASELINE CFE_PSP_IMPL_STR(CFE_PSP_IMPL_BUILD_NUMBER)
+#define CFE_PSP_IMPL_VERSION CFE_PSP_IMPL_BUILD_BASELINE "+dev" CFE_PSP_IMPL_STR(CFE_PSP_IMPL_BUILD_NUMBER)
 
-/*! @brief Development Build Version String.
+/*! @brief DEVELOPMENT Build Version String.
  *  @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
  * official version. @n See @ref cfsversions for format differences between development and release versions.
  */

--- a/fsw/shared/src/cfe_psp_configdata.c
+++ b/fsw/shared/src/cfe_psp_configdata.c
@@ -45,8 +45,8 @@ Target_PspConfigData GLOBAL_PSP_CONFIGDATA = {.PSP_WatchdogMin  = CFE_PSP_WATCHD
 
                                               .HW_NumEepromBanks = CFE_PSP_NUM_EEPROM_BANKS,
 
-                                              .PSP_VersionInfo = {.MajorVersion = CFE_PSP_IMPL_MAJOR_VERSION,
-                                                                  .MinorVersion = CFE_PSP_IMPL_MINOR_VERSION,
-                                                                  .Revision     = CFE_PSP_IMPL_REVISION,
-                                                                  .MissionRev   = CFE_PSP_IMPL_MISSION_REV,
-                                                                  .Version      = CFE_PSP_IMPL_VERSION}};
+                                              .PSP_VersionInfo = {.MajorVersion  = CFE_PSP_IMPL_MAJOR_VERSION,
+                                                                  .MinorVersion  = CFE_PSP_IMPL_MINOR_VERSION,
+                                                                  .Revision      = CFE_PSP_IMPL_REVISION,
+                                                                  .MissionRev    = CFE_PSP_IMPL_MISSION_REV,
+                                                                  .VersionString = CFE_PSP_IMPL_VERSION}};


### PR DESCRIPTION
**Describe the contribution**
Fix #241, Version String not reported correctly

Increase size of `Version` element of `CFE_PSP_VersionInfo_t` to char[32] and rename as `VersionString`


**Testing performed**
Ran on local linux host, cFE EVS output now shows correct format for psp development version

```
EVS Port1 66/1/CFE_ES 2: cFS Versions: cfe v6.8.0-rc1+dev248, osal v5.1.0-rc1+dev184, psp v1.5.0-rc1+dev46. cFE chksm 43674
```

**Expected behavior changes**
Version report matches osal and cfe for development versions. 

Increased structure 

**System(s) tested on**
Ubuntu

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
@astrogeco 