### PR TITLE
psp Integration candidate: 2021-01-19

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ This is a collection of APIs abstracting platform specific functionality to be l
 
 ## Version History
 
+### Development Build: 1.5.0-rc1+dev58
+
+- Add `Security.md` with instructions on reporting vulnerabilities.
+- Rename `UT_ClearForceFail` as `UT_ClearDefaultValue` to reflect <https://github.com/nasa/osal/issues/724>
+- Remove unused elements in `CFE_PSP_ModuleType_t` enum to avoids irregular enum warning
+- See <https://github.com/nasa/PSP/pull/243>
+
 ### Development Build: 1.5.0-rc1+dev50
 
 -  Instead of accessing `OS_time_t` member values directly, use the OSAL-provided conversion and access methods. This provides independence and abstraction from the specific `OS_time_t` definition and allows OSAL to transition to a 64 bit value.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report a vulnerability for the PSP subsystem please [submit an issue](https://github.com/nasa/psp/issues/new/choose).
+
+For general cFS vulnerabilities please [open a cFS framework issue](https://github.com/nasa/cfs/issues/new/choose) and see our [top-level security policy](https://github.com/nasa/cFS/security/policy).
+
+In either case please use the "Bug Report" template and provide as much information as possible. Apply appropraite labels for each report. For security related reports, tag the issue with the "security" label.
+
+## Additional Support
+
+For additional support, email us at cfs-program@lists.nasa.gov. For help using OSAL and cFS, [subscribe to our mailing list](https://lists.nasa.gov/mailman/listinfo/cfs-community) that includes all the community members/users of the NASA core Flight Software (cFS) product line. The mailing list is used to communicate any information related to the cFS product such as current releases, bug findings and fixes, enhancement requests, community meeting notifications, sending out meeting minutes, etc.
+
+If you wish to report a cybersecurity incident or concern please contact the NASA Security Operations Center either by phone at 1-877-627-2732 or via email address soc@nasa.gov.

--- a/fsw/mcp750-vxworks/inc/psp_version.h
+++ b/fsw/mcp750-vxworks/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 50
+#define CFE_PSP_IMPL_BUILD_NUMBER 58
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-linux/inc/psp_version.h
+++ b/fsw/pc-linux/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER 50
+#define CFE_PSP_IMPL_BUILD_NUMBER 58
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-rtems/inc/psp_version.h
+++ b/fsw/pc-rtems/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER   50
+#define CFE_PSP_IMPL_BUILD_NUMBER   58
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/shared/inc/cfe_psp_module.h
+++ b/fsw/shared/inc/cfe_psp_module.h
@@ -36,10 +36,8 @@
 typedef enum
 {
     CFE_PSP_MODULE_TYPE_INVALID = 0,
-    CFE_PSP_MODULE_TYPE_VALID_RANGE  = 1000,
-    CFE_PSP_MODULE_TYPE_SIMPLE,
+    CFE_PSP_MODULE_TYPE_SIMPLE
     /* May be extended in the future */
-    CFE_PSP_MODULE_TYPE_MAX
 } CFE_PSP_ModuleType_t;
 
 /**

--- a/fsw/shared/src/cfe_psp_module.c
+++ b/fsw/shared/src/cfe_psp_module.c
@@ -65,8 +65,7 @@ void CFE_PSP_ModuleInit(void)
         while(Entry->Name != NULL)
         {
             ApiPtr = (CFE_PSP_ModuleApi_t *)Entry->Api;
-            if ((uint32)ApiPtr->ModuleType > CFE_PSP_MODULE_TYPE_VALID_RANGE &&
-                    (uint32)ApiPtr->ModuleType < CFE_PSP_MODULE_TYPE_MAX &&
+            if ((uint32)ApiPtr->ModuleType == CFE_PSP_MODULE_TYPE_SIMPLE &&
                     ApiPtr->Init != NULL)
             {
                 (*ApiPtr->Init)(CFE_PSP_MODULE_BASE | CFE_PSP_ModuleCount);

--- a/unit-test-coverage/mcp750-vxworks/src/coveragetest-cfe-psp-start.c
+++ b/unit-test-coverage/mcp750-vxworks/src/coveragetest-cfe-psp-start.c
@@ -79,14 +79,14 @@ void Test_OS_Application_Startup(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_API_Init), OS_ERROR);
     UT_OS_Application_Startup();
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(PCS_exit)), 1);
-    UT_ClearForceFail(UT_KEY(OS_API_Init));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_API_Init));
 
     /* failure of OS_FileSysAddFixedMap - an extra OS_printf */
     UT_SetDefaultReturnValue(UT_KEY(OS_FileSysAddFixedMap), OS_ERROR);
     UT_OS_Application_Startup();
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(OS_printf)), 9);
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(PCS_SystemMain)), 2);
-    UT_ClearForceFail(UT_KEY(OS_FileSysAddFixedMap));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_FileSysAddFixedMap));
 
     /* coverage for each of the reset types */
     *PCS_SYS_REG_BLRR = PCS_SYS_REG_BLRR_PWRON;

--- a/unit-test-coverage/shared/src/coveragetest-cfe-psp-exceptionstorage.c
+++ b/unit-test-coverage/shared/src/coveragetest-cfe-psp-exceptionstorage.c
@@ -113,7 +113,7 @@ void Test_CFE_PSP_Exception_GetSummary(void)
     CFE_PSP_Exception_WriteComplete();
     UT_SetDefaultReturnValue(UT_KEY(OS_TaskFindIdBySystemData), OS_ERROR);
     UtAssert_INT32_EQ(CFE_PSP_Exception_GetSummary(&LogId, &TaskId, ReasonBuf, sizeof(ReasonBuf)), CFE_PSP_SUCCESS);
-    UT_ClearForceFail(UT_KEY(OS_TaskFindIdBySystemData));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_TaskFindIdBySystemData));
     UtAssert_NONZERO(LogId);
     UtAssert_ZERO(OS_ObjectIdToInteger(TaskId));
 


### PR DESCRIPTION
**Describe the contribution**

Fix #228, Refactor UT_ClearForceFail to UT_ClearDefaultReturnValue
Fix #126, Refactor CFE_PSP_ModuleType_t enum
Fix #236, Create Security Policy

**Testing performed**
See https://github.com/nasa/cFS/pull/177/checks

**Expected behavior changes**

PR #239 - Add `Security.md` with instructions on reporting vulnerabilities.

PR #229 - Rename `UT_ClearForceFail` as `UT_ClearDefaultValue` to reflect <https://github.com/nasa/osal/issues/724>

PR #235 - Remove unused elements in `CFE_PSP_ModuleType_t` enum to avoids irregular enum warning

**System(s) tested on**
Ubuntu 18.04

**Additional context**
Part of https://github.com/nasa/cFS/pull/177

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
@skliper 
@zanzaben 
@ArielSAdamsNASA 
