### PR TITLE
Fix #254, use CMake to publish interface details

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,15 +18,33 @@ add_definitions(-D_CFE_PSP_)
 # The "shared" component is compiled using headers from the platform-specific module
 # so it is still ultimately a platform-specific binary, and it all gets wrapped into
 # a single PSP static library target.
-include_directories(fsw/shared/inc)
+include_directories(
+    fsw/inc
+    fsw/shared/inc  # all local stuff
+    ${CFE_SOURCE_DIR}/cmake/target/inc    # for sysconfig
+    $<TARGET_PROPERTY:osal,INTERFACE_INCLUDE_DIRECTORIES>  # headers from OSAL
+)
+
 add_subdirectory(fsw/${CFE_PSP_TARGETNAME} ${CFE_PSP_TARGETNAME}-impl)
+target_compile_definitions(psp-${CFE_PSP_TARGETNAME}-impl PUBLIC
+    $<TARGET_PROPERTY:osal,INTERFACE_COMPILE_DEFINITIONS> # defs from OSAL
+)
+
 add_subdirectory(fsw/shared ${CFE_PSP_TARGETNAME}-shared)
+target_compile_definitions(psp-${CFE_PSP_TARGETNAME}-shared PUBLIC
+    $<TARGET_PROPERTY:osal,INTERFACE_COMPILE_DEFINITIONS> # defs from OSAL
+)
 
 add_library(psp-${CFE_PSP_TARGETNAME} STATIC
     $<TARGET_OBJECTS:psp-${CFE_PSP_TARGETNAME}-shared>
     $<TARGET_OBJECTS:psp-${CFE_PSP_TARGETNAME}-impl>
 )
-    
+
+target_include_directories(psp-${CFE_PSP_TARGETNAME} INTERFACE 
+    fsw/inc
+)
+
+
 if (ENABLE_UNIT_TESTS)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ut-stubs)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/unit-test-coverage)


### PR DESCRIPTION
**Describe the contribution**
Use `target_include_directories` and `target_compile_definitions` to propagate the interface details for PSP

Fixes #254

**Testing performed**
Build and sanity check CFE, confirm building successfully

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu 20.04

**Additional context**
This becomes required to support nasa/cfe#1203

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.