### PR TITLE
Fix #256, add PSP version API

### DIFF
--- a/fsw/inc/cfe_psp.h
+++ b/fsw/inc/cfe_psp.h
@@ -410,4 +410,59 @@ int32 CFE_PSP_EepromWriteDisable(uint32 Bank);
 int32 CFE_PSP_EepromPowerUp(uint32 Bank);
 int32 CFE_PSP_EepromPowerDown(uint32 Bank);
 
+/**
+ * \brief Obtain the PSP version/baseline identifier string
+ *
+ * This retrieves the PSP version identifier string without extra info
+ *
+ * \returns Version string.  This is a fixed string and cannot be NULL.
+ */
+const char *CFE_PSP_GetVersionString(void);
+
+/**
+ * \brief Obtain the version code name
+ *
+ * This retrieves the PSP code name.  This is a compatibility indicator for the
+ * overall NASA CFS ecosystem.  All modular components which are intended to
+ * interoperate should report the same code name.
+ *
+ * \returns Code name.  This is a fixed string and cannot be NULL.
+ */
+const char *CFE_PSP_GetVersionCodeName(void);
+
+/**
+ * \brief Obtain the PSP numeric version numbers as uint8 values
+ *
+ * This retrieves the numeric PSP version identifier as an array of 4 uint8 values.
+ *
+ * The array of numeric values is in order of precedence:
+ *  [0] = Major Number
+ *  [1] = Minor Number
+ *  [2] = Revision Number
+ *  [3] = Mission Revision
+ *
+ * The "Mission Revision" (last output) also indicates whether this is an
+ * official release, a patched release, or a development version.
+ *  0 indicates an official release
+ *  1-254 local patch level (reserved for mission use)
+ *  255 indicates a development build
+ *
+ * \param[out] VersionNumbers  A fixed-size array to be filled with the version numbers
+ */
+void CFE_PSP_GetVersionNumber(uint8 VersionNumbers[4]);
+
+/**
+ * \brief Obtain the PSP library numeric build number
+ *
+ * The build number is a monotonically increasing number that (coarsely)
+ * reflects the number of commits/changes that have been merged since the
+ * epoch release.  During development cycles this number should increase
+ * after each subsequent merge/modification.
+ *
+ * Like other version information, this is a fixed number assigned at compile time.
+ *
+ * \returns The OSAL library build number
+ */
+uint32 CFE_PSP_GetBuildNumber(void);
+
 #endif /* _cfe_psp_ */

--- a/fsw/inc/cfe_psp_configdata.h
+++ b/fsw/inc/cfe_psp_configdata.h
@@ -39,11 +39,13 @@
 */
 typedef const struct
 {
-    uint8 MajorVersion;
-    uint8 MinorVersion;
-    uint8 Revision;
-    uint8 MissionRev;
-    char  VersionString[32];
+    uint8       MajorVersion;
+    uint8       MinorVersion;
+    uint8       Revision;
+    uint8       MissionRev;
+    const char *VersionString;   /**< The simple semantic version identifier */
+    const char *VersionCodeName; /**< Cross-module compatiblity indicator */
+    uint32      BuildNumber;
 } CFE_PSP_VersionInfo_t;
 
 /**

--- a/fsw/shared/src/cfe_psp_version.c
+++ b/fsw/shared/src/cfe_psp_version.c
@@ -1,0 +1,83 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * \file cfe_psp_version.c
+ *
+ * Defines API that obtains the values of the various version identifiers
+ */
+
+#include <cfe_psp.h>
+#include <cfe_psp_configdata.h>
+
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_PSP_GetVersionString
+ *
+ *  Purpose: Implemented per public OSAL API
+ *           See description in API and header file for detail
+ *
+ *-----------------------------------------------------------------*/
+const char *CFE_PSP_GetVersionString(void)
+{
+    return GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.VersionString;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_PSP_GetVersionCodeName
+ *
+ *  Purpose: Implemented per public OSAL API
+ *           See description in API and header file for detail
+ *
+ *-----------------------------------------------------------------*/
+const char *CFE_PSP_GetVersionCodeName(void)
+{
+    return GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.VersionCodeName;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_PSP_GetVersionNumber
+ *
+ *  Purpose: Implemented per public OSAL API
+ *           See description in API and header file for detail
+ *
+ *-----------------------------------------------------------------*/
+void CFE_PSP_GetVersionNumber(uint8 VersionNumbers[4])
+{
+    VersionNumbers[0] = GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.MajorVersion;
+    VersionNumbers[1] = GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.MinorVersion;
+    VersionNumbers[2] = GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.Revision;
+    VersionNumbers[3] = GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.MissionRev;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_PSP_GetBuildNumber
+ *
+ *  Purpose: Implemented per public OSAL API
+ *           See description in API and header file for detail
+ *
+ *-----------------------------------------------------------------*/
+uint32 CFE_PSP_GetBuildNumber(void)
+{
+    return GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.BuildNumber;
+}

--- a/ut-stubs/ut_psp_stubs.c
+++ b/ut-stubs/ut_psp_stubs.c
@@ -733,3 +733,88 @@ int32 CFE_PSP_Exception_CopyContext(uint32 ContextLogId, void *ContextBuf, uint3
 
     return status;
 }
+
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_PSP_GetVersionString
+ *
+ *  Purpose: Implemented per public OSAL API
+ *           See description in API and header file for detail
+ *
+ *-----------------------------------------------------------------*/
+const char *CFE_PSP_GetVersionString(void)
+{
+    static const char DEFAULT[] = "UT";
+    void *            Buffer;
+    const char *      RetVal;
+
+    UT_GetDataBuffer(UT_KEY(CFE_PSP_GetVersionString), &Buffer, NULL, NULL);
+    if (Buffer == NULL)
+    {
+        RetVal = DEFAULT;
+    }
+    else
+    {
+        RetVal = Buffer;
+    }
+
+    return RetVal;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_PSP_GetVersionCodeName
+ *
+ *  Purpose: Implemented per public OSAL API
+ *           See description in API and header file for detail
+ *
+ *-----------------------------------------------------------------*/
+const char *CFE_PSP_GetVersionCodeName(void)
+{
+    static const char DEFAULT[] = "UT";
+    void *            Buffer;
+    const char *      RetVal;
+
+    UT_GetDataBuffer(UT_KEY(CFE_PSP_GetVersionCodeName), &Buffer, NULL, NULL);
+    if (Buffer == NULL)
+    {
+        RetVal = DEFAULT;
+    }
+    else
+    {
+        RetVal = Buffer;
+    }
+
+    return RetVal;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_PSP_GetVersionNumber
+ *
+ *  Purpose: Implemented per public OSAL API
+ *           See description in API and header file for detail
+ *
+ *-----------------------------------------------------------------*/
+void CFE_PSP_GetVersionNumber(uint8 VersionNumbers[4])
+{
+    UT_Stub_RegisterContext(UT_KEY(CFE_PSP_GetVersionNumber), VersionNumbers);
+    UT_DEFAULT_IMPL(VersionNumbers);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_PSP_GetBuildNumber
+ *
+ *  Purpose: Implemented per public OSAL API
+ *           See description in API and header file for detail
+ *
+ *-----------------------------------------------------------------*/
+uint32 CFE_PSP_GetBuildNumber(void)
+{
+    int32 status;
+
+    status = UT_DEFAULT_IMPL(CFE_PSP_GetBuildNumber);
+
+    return status;
+}


### PR DESCRIPTION
**Describe the contribution**
Add a PSP implementation of the version API discussed in nasa/cFS#200

Fixes #256

**Testing performed**
Build CFE and sanity check

**Expected behavior changes**
Adds an API to get version info rather than using macros/globals.
This just returns the values of the globals.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Attempting to make the version info patterns consistent between all components.  See nasa/cFS#200 for full background.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
