### PR TITLE
Fix #258, Add Testing Tools to the Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,34 @@ For general cFS vulnerabilities please [open a cFS framework issue](https://gith
 
 In either case please use the "Bug Report" template and provide as much information as possible. Apply appropraite labels for each report. For security related reports, tag the issue with the "security" label.
 
+## Testing
+
+**Disclaimer: nasa/PSP is not responsible for any liability incurred under the [Apache License 2.0](https://github.com/nasa/PSP/blob/main/LICENSE).**
+
+Testing is an important aspect our team values to improve PSP. 
+
+To view tools used for the cFS bundle, see our [top-level security policy](https://github.com/nasa/cFS/security/policy). 
+
+### CodeQL
+
+The [PSP CodeQL GitHub Actions workflow](https://github.com/nasa/PSP/actions/workflows/codeql-build.yml) is available to the public. To review the results, fork the PSP repository and run the CodeQL workflow. 
+
+CodeQL is ran for every push and pull-request on all branches of PSP in GitHub Actions. 
+
+For the CodeQL GitHub Actions setup, visit https://github.com/github/codeql-action. 
+
+### Cppcheck
+
+The [PSP Cppcheck GitHub Actions workflow and results](https://github.com/nasa/PSP/actions/workflows/static-analysis.yml) are available to the public. To view the results, select a workflow and download the artifacts. 
+
+Cppcheck is ran for every push on the main branch and every pull request on all branches of PSP in Github Actions. 
+
+For more information about Cppcheck, visit http://cppcheck.sourceforge.net/.
+
 ## Additional Support
 
-For additional support, email us at cfs-program@lists.nasa.gov. For help using OSAL and cFS, [subscribe to our mailing list](https://lists.nasa.gov/mailman/listinfo/cfs-community) that includes all the community members/users of the NASA core Flight Software (cFS) product line. The mailing list is used to communicate any information related to the cFS product such as current releases, bug findings and fixes, enhancement requests, community meeting notifications, sending out meeting minutes, etc.
+For additional support, submit a GitHub issue. You can also email the cfs community at cfs-community@lists.nasa.gov. 
 
-If you wish to report a cybersecurity incident or concern please contact the NASA Security Operations Center either by phone at 1-877-627-2732 or via email address soc@nasa.gov.
+You can subscribe to the mailing list [here](https://lists.nasa.gov/mailman/listinfo/cfs-community) that includes all the community members/users of the NASA core Flight Software (cFS) product line. The mailing list is used to communicate any information related to the cFS product such as current releases, bug findings and fixes, enhancement requests, community meeting notifications, sending out meeting minutes, etc.
+
+If you wish to report a cybersecurity incident or concern, please contact the NASA Security Operations Center either by phone at 1-877-627-2732 or via email address soc@nasa.gov.


### PR DESCRIPTION
**Describe the contribution**
Fix #258 
Updated the Security Policy to include the type of testing done for PSP or the cFS bundle under a new section titled "Testing". Provided a disclaimer that under the Apache license, liability is not provided. 

Added that security reports should be emailed. 

**Expected behavior changes**
Users should now be aware of the type of testing PSP or the cFS bundle undergoes. 

**Additional context**
References: 
https://github.com/thanos-io/thanos/security/policy
https://github.com/phpMussel/phpMussel/security/policy
https://github.com/timberio/vector/security/policy

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal 
