### PR TITLE
Fix #261, add psp_module_api interface target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,29 +11,28 @@ if (NOT CFE_SYSTEM_PSPNAME)
 endif()
 
 set(CFE_PSP_TARGETNAME "${CFE_SYSTEM_PSPNAME}")
-add_definitions(-D_CFE_PSP_)
+add_definitions(-D_CFE_PSP_)       # macro to indicate PSP scope
+
+# The "psp_module_api" defines the interface between internal PSP components
+add_library(psp_module_api INTERFACE)
+target_compile_definitions(psp_module_api INTERFACE
+    $<TARGET_PROPERTY:osal,INTERFACE_COMPILE_DEFINITIONS> # use defs from OSAL
+)
+target_include_directories(psp_module_api INTERFACE
+    fsw/inc         # public API
+    fsw/shared/inc  # all PSP shared headers
+    ${CFE_SOURCE_DIR}/cmake/target/inc    # for sysconfig
+    $<TARGET_PROPERTY:osal,INTERFACE_INCLUDE_DIRECTORIES>  # use headers from OSAL
+)
+
 
 # The PSP is currently built in two parts, consisting of a fully platform-specific
 # module combined with a shared component which is built for multiple targets.
 # The "shared" component is compiled using headers from the platform-specific module
 # so it is still ultimately a platform-specific binary, and it all gets wrapped into
 # a single PSP static library target.
-include_directories(
-    fsw/inc
-    fsw/shared/inc  # all local stuff
-    ${CFE_SOURCE_DIR}/cmake/target/inc    # for sysconfig
-    $<TARGET_PROPERTY:osal,INTERFACE_INCLUDE_DIRECTORIES>  # headers from OSAL
-)
-
 add_subdirectory(fsw/${CFE_PSP_TARGETNAME} ${CFE_PSP_TARGETNAME}-impl)
-target_compile_definitions(psp-${CFE_PSP_TARGETNAME}-impl PUBLIC
-    $<TARGET_PROPERTY:osal,INTERFACE_COMPILE_DEFINITIONS> # defs from OSAL
-)
-
 add_subdirectory(fsw/shared ${CFE_PSP_TARGETNAME}-shared)
-target_compile_definitions(psp-${CFE_PSP_TARGETNAME}-shared PUBLIC
-    $<TARGET_PROPERTY:osal,INTERFACE_COMPILE_DEFINITIONS> # defs from OSAL
-)
 
 add_library(psp-${CFE_PSP_TARGETNAME} STATIC
     $<TARGET_OBJECTS:psp-${CFE_PSP_TARGETNAME}-shared>

--- a/fsw/mcp750-vxworks/CMakeLists.txt
+++ b/fsw/mcp750-vxworks/CMakeLists.txt
@@ -7,8 +7,6 @@
 # This contains the fully platform-specific code to 
 # run CFE on this target.
 
-include_directories(inc) 
-
 # Build the mcp750-vxworks implementation as a library
 add_library(psp-${CFE_PSP_TARGETNAME}-impl OBJECT
     src/cfe_psp_exception.c
@@ -18,5 +16,7 @@ add_library(psp-${CFE_PSP_TARGETNAME}-impl OBJECT
     src/cfe_psp_start.c
     src/cfe_psp_support.c
     src/cfe_psp_timer.c
-    src/cfe_psp_watchdog.c)
-
+    src/cfe_psp_watchdog.c
+)
+target_include_directories(psp-${CFE_PSP_TARGETNAME}-impl PRIVATE inc)
+target_link_libraries(psp-${CFE_PSP_TARGETNAME}-impl PRIVATE psp_module_api)

--- a/fsw/pc-linux/CMakeLists.txt
+++ b/fsw/pc-linux/CMakeLists.txt
@@ -7,8 +7,6 @@
 # This contains the fully platform-specific code to 
 # run CFE on this target.
 
-include_directories(inc) 
-
 # Build the pc-linux implementation as a library
 add_library(psp-${CFE_PSP_TARGETNAME}-impl OBJECT
     src/cfe_psp_exception.c
@@ -26,3 +24,6 @@ add_library(psp-${CFE_PSP_TARGETNAME}-impl OBJECT
 target_compile_definitions(psp-${CFE_SYSTEM_PSPNAME}-impl PRIVATE
     _GNU_SOURCE
 )
+
+target_include_directories(psp-${CFE_PSP_TARGETNAME}-impl PRIVATE inc)
+target_link_libraries(psp-${CFE_PSP_TARGETNAME}-impl PRIVATE psp_module_api)

--- a/fsw/pc-rtems/CMakeLists.txt
+++ b/fsw/pc-rtems/CMakeLists.txt
@@ -7,8 +7,6 @@
 # This contains the fully platform-specific code to 
 # run CFE on this target.
 
-include_directories(inc) 
-
 # Build the pc-rtems implementation as a library
 add_library(psp-${CFE_PSP_TARGETNAME}-impl OBJECT
     src/cfe_psp_exception.c
@@ -18,5 +16,8 @@ add_library(psp-${CFE_PSP_TARGETNAME}-impl OBJECT
     src/cfe_psp_start.c
     src/cfe_psp_support.c
     src/cfe_psp_timer.c
-    src/cfe_psp_watchdog.c)
+    src/cfe_psp_watchdog.c
+)
+target_include_directories(psp-${CFE_PSP_TARGETNAME}-impl PRIVATE inc)
+target_link_libraries(psp-${CFE_PSP_TARGETNAME}-impl PRIVATE psp_module_api)
 

--- a/fsw/shared/CMakeLists.txt
+++ b/fsw/shared/CMakeLists.txt
@@ -10,8 +10,6 @@
 # Note this shared PSP code is currently built against headers provided by the
 # target implementation.  This makes it implementation-specific even though
 # the same source code is used with multiple targets.
-include_directories("${CFEPSP_SOURCE_DIR}/fsw/${CFE_PSP_TARGETNAME}/inc")
-include_directories(inc)
 
 # Build the shared implementation as a library
 add_library(psp-${CFE_PSP_TARGETNAME}-shared OBJECT
@@ -24,3 +22,8 @@ add_library(psp-${CFE_PSP_TARGETNAME}-shared OBJECT
     src/cfe_psp_port.c
     src/cfe_psp_ram.c
 )
+
+target_include_directories(psp-${CFE_PSP_TARGETNAME}-shared PRIVATE 
+    $<TARGET_PROPERTY:psp-${CFE_PSP_TARGETNAME}-impl,INCLUDE_DIRECTORIES>
+)
+target_link_libraries(psp-${CFE_PSP_TARGETNAME}-shared PRIVATE psp_module_api)

--- a/unit-test-coverage/mcp750-vxworks/CMakeLists.txt
+++ b/unit-test-coverage/mcp750-vxworks/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(coverage-${CFE_PSP_TARGETNAME}-testrunner
 target_link_libraries(coverage-${CFE_PSP_TARGETNAME}-testrunner
     ${UT_COVERAGE_LINK_FLAGS}
     ut-adaptor-${CFE_PSP_TARGETNAME}
+    psp_module_api
     ut_psp_cfe_stubs
     ut_psp_libc_stubs
     ut_osapi_stubs

--- a/unit-test-coverage/mcp750-vxworks/adaptors/CMakeLists.txt
+++ b/unit-test-coverage/mcp750-vxworks/adaptors/CMakeLists.txt
@@ -31,3 +31,8 @@ target_include_directories(ut-adaptor-${CFE_PSP_TARGETNAME} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/inc
     ${PSPCOVERAGE_SOURCE_DIR}/shared/adaptors/inc
 )
+
+target_link_libraries(ut-adaptor-${CFE_PSP_TARGETNAME} PRIVATE 
+    psp_module_api
+    ut_assert 
+)

--- a/unit-test-coverage/ut-stubs/CMakeLists.txt
+++ b/unit-test-coverage/ut-stubs/CMakeLists.txt
@@ -54,7 +54,17 @@ add_library(ut_psp_libc_stubs STATIC EXCLUDE_FROM_ALL
 target_include_directories(ut_libc_stubs PUBLIC 
     ${CMAKE_CURRENT_SOURCE_DIR}/inc
 )
+
+target_link_libraries(ut_psp_libc_stubs PRIVATE 
+    psp_module_api
+    ut_assert 
+)
     
 add_library(ut_psp_cfe_stubs STATIC EXCLUDE_FROM_ALL
     src/cfe-configdata-stubs.c
+)
+
+target_link_libraries(ut_psp_cfe_stubs PRIVATE 
+    psp_module_api
+    ut_assert 
 )

--- a/ut-stubs/CMakeLists.txt
+++ b/ut-stubs/CMakeLists.txt
@@ -1,2 +1,5 @@
-include_directories(${osal_MISSION_DIR}/ut_assert/inc)
 add_library(ut_psp-${CFE_PSP_TARGETNAME}_stubs ut_psp_stubs.c)
+target_link_libraries(ut_psp-${CFE_PSP_TARGETNAME}_stubs PRIVATE 
+    psp_module_api
+    ut_assert 
+)


### PR DESCRIPTION
**Describe the contribution**
Adds a new target for PSP modules and use this to propagate the compile definitions and include directories for all PSP code.

This is basically analogous to the `core_private` interface library provided by CFE, but for PSP code.   It is used by PSP internal components and extensions.  The public/external PSP API is still provided by the interface properties on the normal (static) PSP library.

Fixes #261

**Testing performed**
Build and sanity check CFE
run all unit tests

**Expected behavior changes**
No impact to behavior (build system change only)

**System(s) tested on**
Ubuntu 20.04

**Additional context**
nasa/cfe#1203 will also require this.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
