### PR TITLE
Fix #277, add version file

### DIFF
--- a/fsw/shared/CMakeLists.txt
+++ b/fsw/shared/CMakeLists.txt
@@ -20,13 +20,14 @@ add_library(psp-${CFE_PSP_TARGETNAME}-shared OBJECT
     src/cfe_psp_module.c
     src/cfe_psp_port.c
     src/cfe_psp_ram.c
+    src/cfe_psp_version.c
 )
 
 target_compile_definitions(psp-${CFE_SYSTEM_PSPNAME}-shared PRIVATE
     $<TARGET_PROPERTY:psp_module_api,INTERFACE_COMPILE_DEFINITIONS>
 )
 
-target_include_directories(psp-${CFE_PSP_TARGETNAME}-shared PRIVATE 
+target_include_directories(psp-${CFE_PSP_TARGETNAME}-shared PRIVATE
     $<TARGET_PROPERTY:psp_module_api,INTERFACE_INCLUDE_DIRECTORIES>
 )
 


### PR DESCRIPTION
**Describe the contribution**
cfe_psp_version.c should have been included in the source list, but was mistakenly omitted in previous PR.

Fixes #277

**Testing performed**
Build and sanity check CFE, run unit tests

**Expected behavior changes**
References to version API will now successfully link

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Corrects an omission from #257.
Required for nasa/cfe#1255 to work.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.