### PR TITLE
psp Integration candidate: 2021-03-30

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ This is a collection of APIs abstracting platform specific functionality to be l
 
 ## Version History
 
+### Development Build: v1.5.0-rc1+dev95
+
+- Includes `cfe_psp_version.c` in the cmake source list, which was mistakenly omitted previously.
+- Applied the patch and confirmed that CS Cmake unit tests build. Unit tests relying on `CFE_PSP_GetKernelTextSegmentInfo` will build.
+- See <https://github.com/nasa/PSP/pull/279>
+
 ### Development Build: v1.5.0-rc1+dev90
 
 - Addresses the issue of incompatible/non-portable code blobs in the "shared" directory. It uses the same modular init pattern as is used elsewhere in cFE: CMake generates a list of "base" modules correlating with the selected PSP (i.e. pc-linux, mcp750-vxworks, etc) and these modules are then initialized (in order) before the rest of PSP runs. The "direct write" EEPROM is not used unconditionally. Instead the proper eeprom implementation module is selected based on which PSP is selected. MCP750 uses direct write, pc-linux uses an mmap file, and pc-rtems uses a stub (not implemented).

--- a/fsw/mcp750-vxworks/inc/psp_version.h
+++ b/fsw/mcp750-vxworks/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER   90
+#define CFE_PSP_IMPL_BUILD_NUMBER   95
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-linux/inc/psp_version.h
+++ b/fsw/pc-linux/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER   90
+#define CFE_PSP_IMPL_BUILD_NUMBER   95
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/pc-rtems/inc/psp_version.h
+++ b/fsw/pc-rtems/inc/psp_version.h
@@ -29,7 +29,7 @@
 /*
  * Development Build Macro Definitions
  */
-#define CFE_PSP_IMPL_BUILD_NUMBER   90
+#define CFE_PSP_IMPL_BUILD_NUMBER   95
 #define CFE_PSP_IMPL_BUILD_BASELINE "v1.5.0-rc1"
 
 /*

--- a/fsw/shared/CMakeLists.txt
+++ b/fsw/shared/CMakeLists.txt
@@ -20,13 +20,14 @@ add_library(psp-${CFE_PSP_TARGETNAME}-shared OBJECT
     src/cfe_psp_module.c
     src/cfe_psp_port.c
     src/cfe_psp_ram.c
+    src/cfe_psp_version.c
 )
 
 target_compile_definitions(psp-${CFE_SYSTEM_PSPNAME}-shared PRIVATE
     $<TARGET_PROPERTY:psp_module_api,INTERFACE_COMPILE_DEFINITIONS>
 )
 
-target_include_directories(psp-${CFE_PSP_TARGETNAME}-shared PRIVATE 
+target_include_directories(psp-${CFE_PSP_TARGETNAME}-shared PRIVATE
     $<TARGET_PROPERTY:psp_module_api,INTERFACE_INCLUDE_DIRECTORIES>
 )
 

--- a/ut-stubs/ut_psp_stubs.c
+++ b/ut-stubs/ut_psp_stubs.c
@@ -577,6 +577,51 @@ int32 CFE_PSP_GetCFETextSegmentInfo(cpuaddr *PtrToCFESegment, uint32 *SizeOfCFES
 
 /*****************************************************************************/
 /**
+** \brief CFE_PSP_GetKernelTextSegmentInfo stub function
+**
+** \par Description
+**        This function is used to mimic the response of the PSP function
+**        CFE_PSP_GetKernelTextSegmentInfo.  The user can adjust the response by
+**        setting the values in the BSPGetCFETextRtn structure prior to this
+**        function being called.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        Returns either a user-defined status flag or OS_SUCCESS.
+**
+******************************************************************************/
+int32 CFE_PSP_GetKernelTextSegmentInfo(cpuaddr *PtrToKernelSegment, uint32 *SizeOfKernelSegment)
+{
+    static uint32 LocalTextSegment;
+    int32         status;
+    void *        TempAddr;
+    size_t        TempSize;
+
+    status = UT_DEFAULT_IMPL(CFE_PSP_GetKernelTextSegmentInfo);
+
+    if (status >= 0)
+    {
+        UT_GetDataBuffer(UT_KEY(CFE_PSP_GetKernelTextSegmentInfo), &TempAddr, &TempSize, NULL);
+        if (*PtrToKernelSegment == 0)
+        {
+            /* Backup -- Set the pointer and size to anything */
+            *PtrToKernelSegment  = (cpuaddr)&LocalTextSegment;
+            *SizeOfKernelSegment = sizeof(LocalTextSegment);
+        }
+        else
+        {
+            *PtrToKernelSegment  = (cpuaddr)TempAddr;
+            *SizeOfKernelSegment = TempSize;
+        }
+    }
+
+    return status;
+}
+
+/*****************************************************************************/
+/**
 ** \brief CFE_PSP_MemRead8 stub function
 **
 ** \par Description


### PR DESCRIPTION
### Describe the contribution
Fix #277, add version file 
Fix #275, Adds a UT stub for CFE_PSP_GetKernelTextSegmentInfo

### Testing
psp tests <https://github.com/nasa/PSP/pull/279/checks>
bundle tests <https://github.com/nasa/cFS/pull/227/checks>

**Expected behavior changes**
### PR #278 

Includes `cfe_psp_version.c` in the cmake source list, which was mistakenly omitted previously.

### PR  #276

Applied the patch and confirmed that CS Cmake unit tests build. Unit tests relying on `CFE_PSP_GetKernelTextSegmentInfo` will build.


### Additional Context

Part of <https://github.com/nasa/cFS/pull/227>

### Authors
@ejtimmon 
@jphickey 