### PR TITLE
Fix #10, modularize the ram, port, and eeprom access

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,12 @@ set(GENERATED_EXTERNS)
 set(GENERATED_KEYVALS)
 foreach(PSPMOD ${PSP_TARGET_MODULE_LIST})
     add_subdirectory(fsw/modules/${PSPMOD} ${PSPMOD}-${CFE_PSP_TARGETNAME}-impl)
-    list(APPEND GENERATED_EXTERNS "extern CFE_PSP_ModuleApi_t CFE_PSP_${PSPMOD}_API;\n")
+    list(APPEND GENERATED_EXTERNS "extern CFE_PSP_ModuleApi_t CFE_PSP_${PSPMOD}_API\;\n")
     list(APPEND GENERATED_KEYVALS "{ .Name = \"${PSPMOD}\", .Api = &CFE_PSP_${PSPMOD}_API },\n")
 endforeach()
+
+string(CONCAT GENERATED_EXTERNS ${GENERATED_EXTERNS})
+string(CONCAT GENERATED_KEYVALS ${GENERATED_KEYVALS})
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/module_list.c.in ${CMAKE_CURRENT_BINARY_DIR}/${CFE_PSP_TARGETNAME}_module_list.c @ONLY)
 
@@ -60,7 +63,7 @@ target_link_libraries(psp-${CFE_PSP_TARGETNAME} PRIVATE
     psp_module_api
 )
 
-target_include_directories(psp-${CFE_PSP_TARGETNAME} INTERFACE 
+target_include_directories(psp-${CFE_PSP_TARGETNAME} INTERFACE
     fsw/inc
 )
 

--- a/fsw/mcp750-vxworks/psp_module_list.cmake
+++ b/fsw/mcp750-vxworks/psp_module_list.cmake
@@ -1,4 +1,6 @@
-# This is a list of modules that is included as a fixed/base set 
+# This is a list of modules that is included as a fixed/base set
 # when this PSP is selected.  They must exist under fsw/modules
 
 eeprom_direct
+ram_direct
+port_direct

--- a/fsw/mcp750-vxworks/src/cfe_psp_start.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_start.c
@@ -59,6 +59,7 @@
 
 #include "cfe_psp.h"
 #include "cfe_psp_memory.h"
+#include "cfe_psp_module.h"
 
 /*
 **  External Declarations
@@ -145,6 +146,11 @@ void OS_Application_Startup(void)
     ** This must be done before any of the reset variables are used.
     */
     CFE_PSP_SetupReservedMemoryMap();
+
+    /*
+    ** Initialize the statically linked modules (if any)
+    */
+    CFE_PSP_ModuleInit();
 
     /*
     ** Determine Reset type by reading the hardware reset register.

--- a/fsw/modules/eeprom_notimpl/CMakeLists.txt
+++ b/fsw/modules/eeprom_notimpl/CMakeLists.txt
@@ -1,0 +1,3 @@
+
+# Create the module
+add_psp_module(eeprom_notimpl cfe_psp_eeprom_notimpl.c)

--- a/fsw/modules/eeprom_notimpl/cfe_psp_eeprom_notimpl.c
+++ b/fsw/modules/eeprom_notimpl/cfe_psp_eeprom_notimpl.c
@@ -1,0 +1,74 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * \file cfe_psp_eeprom_notimpl.c
+ *
+ * A PSP module to satisfy the "EEPROM" API on systems which
+ * do not have an EEPROM or otherwise cannot access it.
+ *
+ * All functions return CFE_PSP_ERR_NOT_IMPLEMENTED
+ */
+
+#include "cfe_psp.h"
+#include "cfe_psp_module.h"
+
+CFE_PSP_MODULE_DECLARE_SIMPLE(eeprom_notimpl);
+
+void eeprom_notimpl_Init(uint32 PspModuleId)
+{
+    /* Inform the user that this module is in use */
+    printf("CFE_PSP: EEPROM access not implemented\n");
+}
+
+int32 CFE_PSP_EepromWrite32(cpuaddr MemoryAddress, uint32 uint32Value)
+{
+    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+}
+
+int32 CFE_PSP_EepromWrite16(cpuaddr MemoryAddress, uint16 uint16Value)
+{
+    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+}
+
+int32 CFE_PSP_EepromWrite8(cpuaddr MemoryAddress, uint8 ByteValue)
+{
+    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+}
+
+int32 CFE_PSP_EepromWriteEnable(uint32 Bank)
+{
+    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+}
+
+int32 CFE_PSP_EepromWriteDisable(uint32 Bank)
+{
+    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+}
+
+int32 CFE_PSP_EepromPowerUp(uint32 Bank)
+{
+    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+}
+
+int32 CFE_PSP_EepromPowerDown(uint32 Bank)
+{
+    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+}

--- a/fsw/modules/eeprom_stub/CMakeLists.txt
+++ b/fsw/modules/eeprom_stub/CMakeLists.txt
@@ -1,3 +1,0 @@
-
-# Create the module
-add_psp_module(eeprom_stub cfe_psp_eeprom_stub.c)

--- a/fsw/modules/port_direct/CMakeLists.txt
+++ b/fsw/modules/port_direct/CMakeLists.txt
@@ -1,0 +1,3 @@
+
+# Create the module
+add_psp_module(port_direct cfe_psp_port_direct.c)

--- a/fsw/modules/port_direct/cfe_psp_port_direct.c
+++ b/fsw/modules/port_direct/cfe_psp_port_direct.c
@@ -18,25 +18,23 @@
 **  limitations under the License.
 */
 
-/*
-** File   :	cfe_pep_memport.c
-**
-** Author :	Ezra Yeheskeli
-**
-** Purpose:
-**		   This file  contains some of the cFE Platform Support Layer.
-**         It contains the processor architecture specific calls.
-**
-**  16-Nov-2003 Ezra Yeheskeli
-**          - First Creation.
-**
-*/
-
-/*
-** Include section
-*/
+/**
+ * \file cfe_psp_port_direct.c
+ *
+ * A PSP module to satisfy the "PORT" API on systems which
+ * can access I/O ports directly via memory mapped addresses.
+ */
 
 #include "cfe_psp.h"
+#include "cfe_psp_module.h"
+
+CFE_PSP_MODULE_DECLARE_SIMPLE(port_direct);
+
+void port_direct_Init(uint32 PspModuleId)
+{
+    /* Inform the user that this module is in use */
+    printf("CFE_PSP: Using DIRECT memory mapped PORT implementation\n");
+}
 
 /*
 ** global memory

--- a/fsw/modules/port_notimpl/CMakeLists.txt
+++ b/fsw/modules/port_notimpl/CMakeLists.txt
@@ -1,0 +1,3 @@
+
+# Create the module
+add_psp_module(port_notimpl cfe_psp_port_notimpl.c)

--- a/fsw/modules/port_notimpl/cfe_psp_port_notimpl.c
+++ b/fsw/modules/port_notimpl/cfe_psp_port_notimpl.c
@@ -1,0 +1,69 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * \file cfe_psp_port_notimpl.c
+ *
+ * A PSP module to satisfy the "Port" API on systems which
+ * do not have or otherwise cannot access I/O ports.
+ *
+ * All functions return CFE_PSP_ERR_NOT_IMPLEMENTED
+ */
+
+#include "cfe_psp.h"
+#include "cfe_psp_module.h"
+
+CFE_PSP_MODULE_DECLARE_SIMPLE(port_notimpl);
+
+void port_notimpl_Init(uint32 PspModuleId)
+{
+    /* Inform the user that this module is in use */
+    printf("CFE_PSP: I/O Port access not implemented\n");
+}
+
+int32 CFE_PSP_PortRead8(cpuaddr PortAddress, uint8 *ByteValue)
+{
+    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+}
+
+int32 CFE_PSP_PortWrite8(cpuaddr PortAddress, uint8 ByteValue)
+{
+    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+}
+
+int32 CFE_PSP_PortRead16(cpuaddr PortAddress, uint16 *uint16Value)
+{
+    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+}
+
+int32 CFE_PSP_PortWrite16(cpuaddr PortAddress, uint16 uint16Value)
+{
+    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+}
+
+int32 CFE_PSP_PortRead32(cpuaddr PortAddress, uint32 *uint32Value)
+{
+    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+}
+
+int32 CFE_PSP_PortWrite32(cpuaddr PortAddress, uint32 uint32Value)
+{
+    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+}

--- a/fsw/modules/ram_direct/CMakeLists.txt
+++ b/fsw/modules/ram_direct/CMakeLists.txt
@@ -1,0 +1,3 @@
+
+# Create the module
+add_psp_module(ram_direct cfe_psp_ram_direct.c)

--- a/fsw/modules/ram_direct/cfe_psp_ram_direct.c
+++ b/fsw/modules/ram_direct/cfe_psp_ram_direct.c
@@ -18,25 +18,23 @@
 **  limitations under the License.
 */
 
-/*
-** File   :	cfe_psp_memram.c
-**
-** Author :	Ezra Yeheskeli
-**
-** Purpose:
-**		   This file  contains some of the cFE Platform Support Layer.
-**         It contains the processor architecture specific calls.
-**
-**  16-Nov-2003 Ezra Yeheskeli
-**          - First Creation.
-**
-*/
-
-/*
-** Include section
-*/
+/**
+ * \file cfe_psp_ram_direct.c
+ *
+ * A PSP module to satisfy the "RAM" API on systems which
+ * can access physical memory directly.
+ */
 
 #include "cfe_psp.h"
+#include "cfe_psp_module.h"
+
+CFE_PSP_MODULE_DECLARE_SIMPLE(ram_direct);
+
+void ram_direct_Init(uint32 PspModuleId)
+{
+    /* Inform the user that this module is in use */
+    printf("CFE_PSP: Using DIRECT memory mapped RAM implementation\n");
+}
 
 /*
 ** global memory

--- a/fsw/modules/ram_notimpl/CMakeLists.txt
+++ b/fsw/modules/ram_notimpl/CMakeLists.txt
@@ -1,0 +1,3 @@
+
+# Create the module
+add_psp_module(ram_notimpl cfe_psp_ram_notimpl.c)

--- a/fsw/modules/ram_notimpl/cfe_psp_ram_notimpl.c
+++ b/fsw/modules/ram_notimpl/cfe_psp_ram_notimpl.c
@@ -19,56 +19,51 @@
 */
 
 /**
- * \file cfe_psp_eeprom_stub.c
+ * \file cfe_psp_ram_notimpl.c
  *
- *  Created on: Jul 17, 2015
- *      Author: joseph.p.hickey@nasa.gov
+ * A PSP module to satisfy the "RAM" API on systems which
+ * cannot access physical memory directly.
  *
- * This is a stub implementation of the PSP EEPROM API calls that return CFE_PSP_ERROR_NOT_IMPLEMENTED
+ * All functions return CFE_PSP_ERR_NOT_IMPLEMENTED
  */
 
 #include "cfe_psp.h"
 #include "cfe_psp_module.h"
 
-CFE_PSP_MODULE_DECLARE_SIMPLE(eeprom_stub);
+CFE_PSP_MODULE_DECLARE_SIMPLE(ram_notimpl);
 
-void eeprom_stub_Init(uint32 PspModuleId)
+void ram_notimpl_Init(uint32 PspModuleId)
 {
     /* Inform the user that this module is in use */
-    printf("CFE_PSP: Using STUB EEPROM implementation\n");
+    printf("CFE_PSP: Physical RAM access not implemented\n");
 }
 
-int32 CFE_PSP_EepromWrite32(cpuaddr MemoryAddress, uint32 uint32Value)
+int32 CFE_PSP_MemRead8(cpuaddr MemoryAddress, uint8 *ByteValue)
 {
     return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
 }
 
-int32 CFE_PSP_EepromWrite16(cpuaddr MemoryAddress, uint16 uint16Value)
+int32 CFE_PSP_MemWrite8(cpuaddr MemoryAddress, uint8 ByteValue)
 {
     return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
 }
 
-int32 CFE_PSP_EepromWrite8(cpuaddr MemoryAddress, uint8 ByteValue)
+int32 CFE_PSP_MemRead16(cpuaddr MemoryAddress, uint16 *uint16Value)
 {
     return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
 }
 
-int32 CFE_PSP_EepromWriteEnable(uint32 Bank)
+int32 CFE_PSP_MemWrite16(cpuaddr MemoryAddress, uint16 uint16Value)
 {
     return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
 }
 
-int32 CFE_PSP_EepromWriteDisable(uint32 Bank)
+int32 CFE_PSP_MemRead32(cpuaddr MemoryAddress, uint32 *uint32Value)
 {
     return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
 }
 
-int32 CFE_PSP_EepromPowerUp(uint32 Bank)
-{
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
-}
-
-int32 CFE_PSP_EepromPowerDown(uint32 Bank)
+int32 CFE_PSP_MemWrite32(cpuaddr MemoryAddress, uint32 uint32Value)
 {
     return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
 }

--- a/fsw/pc-linux/psp_module_list.cmake
+++ b/fsw/pc-linux/psp_module_list.cmake
@@ -1,4 +1,6 @@
-# This is a list of modules that is included as a fixed/base set 
+# This is a list of modules that is included as a fixed/base set
 # when this PSP is selected.  They must exist under fsw/modules
 
 eeprom_mmap_file
+ram_notimpl
+port_notimpl

--- a/fsw/pc-rtems/psp_module_list.cmake
+++ b/fsw/pc-rtems/psp_module_list.cmake
@@ -1,4 +1,6 @@
-# This is a list of modules that is included as a fixed/base set 
+# This is a list of modules that is included as a fixed/base set
 # when this PSP is selected.  They must exist under fsw/modules
 
-eeprom_stub
+eeprom_notimpl
+ram_direct
+port_notimpl

--- a/fsw/shared/CMakeLists.txt
+++ b/fsw/shared/CMakeLists.txt
@@ -18,15 +18,13 @@ add_library(psp-${CFE_PSP_TARGETNAME}-shared OBJECT
     src/cfe_psp_memrange.c
     src/cfe_psp_memutils.c
     src/cfe_psp_module.c
-    src/cfe_psp_port.c
-    src/cfe_psp_ram.c
 )
 
 target_compile_definitions(psp-${CFE_SYSTEM_PSPNAME}-shared PRIVATE
     $<TARGET_PROPERTY:psp_module_api,INTERFACE_COMPILE_DEFINITIONS>
 )
 
-target_include_directories(psp-${CFE_PSP_TARGETNAME}-shared PRIVATE 
+target_include_directories(psp-${CFE_PSP_TARGETNAME}-shared PRIVATE
     $<TARGET_PROPERTY:psp_module_api,INTERFACE_INCLUDE_DIRECTORIES>
 )
 


### PR DESCRIPTION
**Describe the contribution**
This is another attempt at resolving the long-standing issue of platform-specific code in the shared directory which is not easy to replace/override.

Convert the current "cfe_psp_ram.c" and "cfe_psp_port.c" routines into modular components, and remove from "shared" dir.  The existing implementations become the corresponding "direct" module, and are enabled based on the psp module selection.

Also added is a "notimpl" variant, where all the functions return CFE_PSP_ERR_NOT_IMPLEMENTED.  This is used on Linux
or any other system where direct access is not possible.

Note this also renames the existing "eeprom_stub" module to be "eeprom_notimpl" for consistency and to avoid any
confusion with the unit test stubs.

Fixes #10

**Testing performed**
Build and sanity check CFE on RTEMS, VxWorks/MCP750 and native Linux
run all unit tests
Confirm that the "direct" implementation of Port/RAM access is used only on VxWorks build
Confirm that the "notimpl" implementation is used on Linux.

**Expected behavior changes**
No longer segfaults if e.g. CFE_PSP_Port routines are invoked on Linux.  Instead an error code is returned.

**System(s) tested on**
Ubuntu 20.04 (native)
MCP750 (vxworks)
RTEMS 4.11.3 + QEMU 

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
