### PR TITLE
Fix #171, use OSAL timebase for CFE timers

### DIFF
--- a/fsw/inc/cfe_psp.h
+++ b/fsw/inc/cfe_psp.h
@@ -153,6 +153,13 @@
 #define CFE_PSP_MISSION_REV   (GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.MissionRev)
 #define CFE_PSP_VERSION       (GLOBAL_PSP_CONFIGDATA.PSP_VersionInfo.VersionString)
 
+/**
+ * \brief The name of the software/RTOS timebase for general system timers.
+ *
+ * This name may be referred to by CFE TIME and/or SCH when setting up its own timers.
+ */
+#define CFE_PSP_SOFT_TIMEBASE_NAME "cFS-Master"
+
 /*
 ** Type Definitions
 */

--- a/fsw/mcp750-vxworks/inc/cfe_psp_config.h
+++ b/fsw/mcp750-vxworks/inc/cfe_psp_config.h
@@ -52,6 +52,16 @@
 #define CFE_PSP_MAX_EXCEPTION_ENTRIES 4
 
 /*
+ * The tick period that will be configured in the RTOS for the simulated
+ * time base, in microseconds.  This in turn is used to drive the 1hz clock
+ * and other functions.
+ *
+ * On the MCP750 the sysClockRate runs at 60Hz so this is the same period
+ * that the cFE software timebase will be configured at.
+ */
+#define CFE_PSP_SOFT_TIMEBASE_PERIOD 16666
+
+/*
 ** Typedef for the layout of the vxWorks boot record structure
 **
 ** This is statically placed at the beginning of system memory (sysMemTop)

--- a/fsw/mcp750-vxworks/psp_module_list.cmake
+++ b/fsw/mcp750-vxworks/psp_module_list.cmake
@@ -1,4 +1,5 @@
-# This is a list of modules that is included as a fixed/base set 
+# This is a list of modules that is included as a fixed/base set
 # when this PSP is selected.  They must exist under fsw/modules
 
+soft_timebase
 eeprom_direct

--- a/fsw/mcp750-vxworks/src/cfe_psp_start.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_start.c
@@ -74,7 +74,6 @@ IMPORT void sysPciWrite32(UINT32, UINT32);
 
 #define CFE_PSP_MAIN_FUNCTION       (*GLOBAL_CONFIGDATA.CfeConfig->SystemMain)
 #define CFE_PSP_NONVOL_STARTUP_FILE (GLOBAL_CONFIGDATA.CfeConfig->NonvolStartupFile)
-#define CFE_PSP_1HZ_FUNCTION        (*GLOBAL_CONFIGDATA.CfeConfig->System1HzISR)
 
 /******************************************************************************
 **  Function:  OS_Application_Startup()
@@ -231,31 +230,4 @@ void OS_Application_Startup(void)
     ** is complete.
     */
     CFE_PSP_MAIN_FUNCTION(reset_type, reset_subtype, 1, CFE_PSP_NONVOL_STARTUP_FILE);
-}
-
-/******************************************************************************
-**  Function:  OS_Application_Run()
-**
-**  Purpose:
-**    Idle Loop entry point from OSAL BSP.
-**
-**  Arguments:
-**    (none)
-**
-**  Return:
-**    (none)
-*/
-void OS_Application_Run(void)
-{
-    int TicksPerSecond;
-
-    /*
-    ** Main loop for default task and simulated 1hz
-    */
-    for (;;)
-    {
-        TicksPerSecond = sysClkRateGet();
-        (void)taskDelay(TicksPerSecond);
-        CFE_PSP_1HZ_FUNCTION();
-    }
 }

--- a/fsw/modules/soft_timebase/CMakeLists.txt
+++ b/fsw/modules/soft_timebase/CMakeLists.txt
@@ -1,0 +1,3 @@
+
+# Create the module
+add_psp_module(soft_timebase cfe_psp_soft_timebase.c)

--- a/fsw/modules/soft_timebase/cfe_psp_soft_timebase.c
+++ b/fsw/modules/soft_timebase/cfe_psp_soft_timebase.c
@@ -1,0 +1,82 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * \file cfe_psp_soft_timebase.c
+ *
+ * A PSP module that instantiates an RTOS-backed OSAL timebase to provide
+ * various timing services.  This in turn may be used to drive CFE TIME 1Hz
+ * signal, the CFS SCH major/minor frame sync and other periodic services
+ * in CFE.
+ *
+ * This module can be used on systems which do not have a hardware
+ * source for the 1Hz signal or timing info (i.e. simulation, test
+ * and debug platforms, etc).
+ */
+
+#include "cfe_psp.h"
+#include "cfe_psp_module.h"
+#include "cfe_psp_config.h"
+
+CFE_PSP_MODULE_DECLARE_SIMPLE(soft_timebase);
+
+/*
+ * Global state data for this module (not exposed publicly)
+ */
+static struct
+{
+    osal_id_t sys_timebase_id;
+} PSP_SoftTimebase_Global;
+
+void soft_timebase_Init(uint32 PspModuleId)
+{
+    int32 status;
+
+    memset(&PSP_SoftTimebase_Global, 0, sizeof(PSP_SoftTimebase_Global));
+
+    /* Set up the OSAL timebase using the well-known name */
+    status = OS_TimeBaseCreate(&PSP_SoftTimebase_Global.sys_timebase_id, CFE_PSP_SOFT_TIMEBASE_NAME, NULL);
+    if (status == OS_SUCCESS)
+    {
+        /* Set the timebase to trigger with desired resolution */
+        status = OS_TimeBaseSet(PSP_SoftTimebase_Global.sys_timebase_id, CFE_PSP_SOFT_TIMEBASE_PERIOD,
+                                CFE_PSP_SOFT_TIMEBASE_PERIOD);
+    }
+
+    /*
+     * The only way this can fail is through a misconfiguration or API incompatibility -
+     * if it fails, it means all timing related functions are likely to be broken,
+     * CFE TIME may not work correctly, and background jobs will not run.
+     *
+     * Might even be worth a CFE_PSP_Panic(), but it still may be possible
+     * to boot CFE and (maybe) save the system by uploading a file with the bug fixed.
+     */
+    if (status != OS_SUCCESS)
+    {
+        printf("CFE_PSP: *** Failed to configure software timebase \'%s\', status = %d! ***\n",
+               CFE_PSP_SOFT_TIMEBASE_NAME, (int)status);
+    }
+    else
+    {
+        /* Inform the user that this module is in use */
+        printf("CFE_PSP: Instantiated software timebase \'%s\' running at %lu usec\n", CFE_PSP_SOFT_TIMEBASE_NAME,
+               (unsigned long)CFE_PSP_SOFT_TIMEBASE_PERIOD);
+    }
+}

--- a/fsw/pc-linux/inc/cfe_psp_config.h
+++ b/fsw/pc-linux/inc/cfe_psp_config.h
@@ -66,6 +66,19 @@
 #define CFE_PSP_EXCEPTION_EVENT_SIGNAL SIGUSR1
 
 /*
+ * The tick period that will be configured in the RTOS for the simulated
+ * time base, in microseconds.  This in turn is used to drive the 1hz clock
+ * and other functions.
+ *
+ * To minimize jitter in the resulting callbacks, it should be an even
+ * divisor of 1000000 usec.
+ *
+ * Note - 10ms/100Hz is chosen to also allow this same timebase to be
+ * used to drive the CFS SCH minor frame callbacks in its default config.
+ */
+#define CFE_PSP_SOFT_TIMEBASE_PERIOD 10000
+
+/*
 ** Global variables
 */
 

--- a/fsw/pc-linux/psp_module_list.cmake
+++ b/fsw/pc-linux/psp_module_list.cmake
@@ -1,4 +1,5 @@
-# This is a list of modules that is included as a fixed/base set 
+# This is a list of modules that is included as a fixed/base set
 # when this PSP is selected.  They must exist under fsw/modules
 
+soft_timebase
 eeprom_mmap_file

--- a/fsw/pc-rtems/inc/cfe_psp_config.h
+++ b/fsw/pc-rtems/inc/cfe_psp_config.h
@@ -44,6 +44,19 @@
 #define CFE_PSP_MAX_EXCEPTION_ENTRIES 1
 
 /*
+ * The tick period that will be configured in the RTOS for the simulated
+ * time base, in microseconds.  This in turn is used to drive the 1hz clock
+ * and other functions.
+ *
+ * To minimize jitter in the resulting callbacks, it should be an even
+ * divisor of 1000000 usec.
+ *
+ * Note - 10ms/100Hz is chosen to also allow this same timebase to be
+ * used to drive the CFS SCH minor frame callbacks in its default config.
+ */
+#define CFE_PSP_SOFT_TIMEBASE_PERIOD 10000
+
+/*
 ** Typedef for the layout of the header in the reserved memory block
 */
 typedef struct

--- a/fsw/pc-rtems/psp_module_list.cmake
+++ b/fsw/pc-rtems/psp_module_list.cmake
@@ -1,4 +1,5 @@
-# This is a list of modules that is included as a fixed/base set 
+# This is a list of modules that is included as a fixed/base set
 # when this PSP is selected.  They must exist under fsw/modules
 
 eeprom_stub
+soft_timebase

--- a/fsw/pc-rtems/src/cfe_psp_start.c
+++ b/fsw/pc-rtems/src/cfe_psp_start.c
@@ -131,51 +131,6 @@ int CFE_PSP_Setup(void)
     return RTEMS_SUCCESSFUL;
 }
 
-/******************************************************************************
-**  Function:  CFE_PSP_SetupSystemTimer
-**
-**  Purpose:
-**    BSP system time base and timer object setup.
-**    This does the necessary work to start the 1Hz time tick required by CFE
-**
-**  Arguments:
-**    (none)
-**
-**  Return:
-**    (none)
-**
-** NOTE:
-**      The handles to the timebase/timer objects are "start and forget"
-**      as they are supposed to run forever as long as CFE runs.
-**
-**      If needed for e.g. additional timer creation, they can be recovered
-**      using an OSAL GetIdByName() call.
-**
-**      This is preferred anyway -- far cleaner than trying to pass the uint32 value
-**      up to the application somehow.
-*/
-
-void CFE_PSP_SetupSystemTimer(void)
-{
-    osal_id_t SystemTimebase;
-    int32     Status;
-
-    Status = OS_TimeBaseCreate(&SystemTimebase, "cFS-Master", NULL);
-    if (Status == OS_SUCCESS)
-    {
-        Status = OS_TimeBaseSet(SystemTimebase, 250000, 250000);
-    }
-
-    /*
-     * If anything failed, cFE/cFS will not run properly, so a panic is appropriate
-     */
-    if (Status != OS_SUCCESS)
-    {
-        OS_printf("CFE_PSP: Error configuring cFS timing: %d\n", (int)Status);
-        CFE_PSP_Panic(Status);
-    }
-}
-
 /*
 ** A simple entry point to start from the BSP loader
 **
@@ -262,9 +217,6 @@ void CFE_PSP_Main(void)
     ** Initialize the statically linked modules (if any)
     */
     CFE_PSP_ModuleInit();
-
-    /* Prepare the system timing resources */
-    CFE_PSP_SetupSystemTimer();
 
     /*
     ** Determine Reset type by reading the hardware reset register.


### PR DESCRIPTION
**Describe the contribution**
Add a new PSP module that instantiates an OSAL abstract timebase for use with cFE services.  This single module is then used
across all 3 implementations (mcp750, pc-linux, pc-rtems) and does not need to be duplicated.

Cleans up stale code from the previous method(s) of generating 1Hz

Fixes #171

**Testing performed**
Build and sanity check CFE, run all unit tests
Make sure 1Hz timing ticks are working as expected

**Expected behavior changes**
1Hz timing tick on MCP750 will be more accurate
No changes to Linux/RTEMS

**System(s) tested on**
MCP750 vxworks 6.9
Ubuntu 20.04
RTEMS 4.11.3 (qemu)

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.