### PR TITLE
Fix #303, check that module type is not invalid

### DIFF
--- a/fsw/shared/src/cfe_psp_module.c
+++ b/fsw/shared/src/cfe_psp_module.c
@@ -64,7 +64,7 @@ void CFE_PSP_ModuleInitList(CFE_StaticModuleLoadEntry_t *ListPtr)
         while (Entry->Name != NULL)
         {
             ApiPtr = (CFE_PSP_ModuleApi_t *)Entry->Api;
-            if ((uint32)ApiPtr->ModuleType == CFE_PSP_MODULE_TYPE_SIMPLE && ApiPtr->Init != NULL)
+            if ((uint32)ApiPtr->ModuleType != CFE_PSP_MODULE_TYPE_INVALID && ApiPtr->Init != NULL)
             {
                 (*ApiPtr->Init)(CFE_PSP_MODULE_BASE | CFE_PSP_ModuleCount);
             }


### PR DESCRIPTION
**Describe the contribution**
Rather than only calling "Init" on a "SIMPLE" module type, just check that it is not invalid instead.  Even extension types
still have an Init routine that needs to be called.

Fixes #303

**Testing performed**
Build and sanity check CFE, including using some HW access extension modules

**Expected behavior changes**
Module gets initialized as it should

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

