### PR TITLE
Fix #313, check the address in PSP get segment stubs

### DIFF
--- a/ut-stubs/ut_psp_stubs.c
+++ b/ut-stubs/ut_psp_stubs.c
@@ -557,7 +557,7 @@ int32 CFE_PSP_GetCFETextSegmentInfo(cpuaddr *PtrToCFESegment, uint32 *SizeOfCFES
     if (status >= 0)
     {
         UT_GetDataBuffer(UT_KEY(CFE_PSP_GetCFETextSegmentInfo), &TempAddr, &TempSize, NULL);
-        if (*PtrToCFESegment == 0)
+        if (TempAddr == NULL)
         {
             /* Backup -- Set the pointer and size to anything */
             *PtrToCFESegment  = (cpuaddr)&LocalTextSegment;
@@ -602,7 +602,7 @@ int32 CFE_PSP_GetKernelTextSegmentInfo(cpuaddr *PtrToKernelSegment, uint32 *Size
     if (status >= 0)
     {
         UT_GetDataBuffer(UT_KEY(CFE_PSP_GetKernelTextSegmentInfo), &TempAddr, &TempSize, NULL);
-        if (*PtrToKernelSegment == 0)
+        if (TempAddr == NULL)
         {
             /* Backup -- Set the pointer and size to anything */
             *PtrToKernelSegment  = (cpuaddr)&LocalTextSegment;


### PR DESCRIPTION
**Describe the contribution**
Checks the correct local variable (TempAddr) to see if the data buffer address was set by the test case

Fixes #313

**Testing performed**
Build and sanity check CFE, run all tests

**Expected behavior changes**
None to FSW
Stub should work correctly in UT

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
