### PR TITLE
Fix #323, Remove explicit filename doxygen comments

### DIFF
--- a/fsw/modules/eeprom_mmap_file/cfe_psp_eeprom_mmap_file.c
+++ b/fsw/modules/eeprom_mmap_file/cfe_psp_eeprom_mmap_file.c
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_psp_eeprom_mmap_file.c
+ * \file
  *
  *  Created on: Jul 17, 2015
  *      Author: joseph.p.hickey@nasa.gov

--- a/fsw/modules/eeprom_notimpl/cfe_psp_eeprom_notimpl.c
+++ b/fsw/modules/eeprom_notimpl/cfe_psp_eeprom_notimpl.c
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_psp_eeprom_notimpl.c
+ * \file
  *
  * A PSP module to satisfy the "EEPROM" API on systems which
  * do not have an EEPROM or otherwise cannot access it.

--- a/fsw/modules/port_direct/cfe_psp_port_direct.c
+++ b/fsw/modules/port_direct/cfe_psp_port_direct.c
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_psp_port_direct.c
+ * \file
  *
  * A PSP module to satisfy the "PORT" API on systems which
  * can access I/O ports directly via memory mapped addresses.

--- a/fsw/modules/port_notimpl/cfe_psp_port_notimpl.c
+++ b/fsw/modules/port_notimpl/cfe_psp_port_notimpl.c
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_psp_port_notimpl.c
+ * \file
  *
  * A PSP module to satisfy the "Port" API on systems which
  * do not have or otherwise cannot access I/O ports.

--- a/fsw/modules/ram_direct/cfe_psp_ram_direct.c
+++ b/fsw/modules/ram_direct/cfe_psp_ram_direct.c
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_psp_ram_direct.c
+ * \file
  *
  * A PSP module to satisfy the "RAM" API on systems which
  * can access physical memory directly.

--- a/fsw/modules/ram_notimpl/cfe_psp_ram_notimpl.c
+++ b/fsw/modules/ram_notimpl/cfe_psp_ram_notimpl.c
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_psp_ram_notimpl.c
+ * \file
  *
  * A PSP module to satisfy the "RAM" API on systems which
  * cannot access physical memory directly.

--- a/fsw/modules/soft_timebase/cfe_psp_soft_timebase.c
+++ b/fsw/modules/soft_timebase/cfe_psp_soft_timebase.c
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_psp_soft_timebase.c
+ * \file
  *
  * A PSP module that instantiates an RTOS-backed OSAL timebase to provide
  * various timing services.  This in turn may be used to drive CFE TIME 1Hz

--- a/fsw/modules/timebase_posix_clock/cfe_psp_timebase_posix_clock.c
+++ b/fsw/modules/timebase_posix_clock/cfe_psp_timebase_posix_clock.c
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_psp_timebase_posix_clock.c
+ * \file
  *
  * A PSP module to satisfy the PSP time API on systems which
  * do not have a hardware clock register, but do provide a POSIX

--- a/fsw/modules/timebase_vxworks/cfe_psp_timebase_vxworks.c
+++ b/fsw/modules/timebase_vxworks/cfe_psp_timebase_vxworks.c
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_psp_timebase_vxworks.c
+ * \file
  *
  * A PSP module to implement the PSP time API via the VxWorks
  * vxTimeBaseGet() routine.  The VxWorks timebase is a 64 bit

--- a/fsw/shared/inc/cfe_psp_exceptionstorage_api.h
+++ b/fsw/shared/inc/cfe_psp_exceptionstorage_api.h
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_psp_exceptionstorage_api.h
+ * \file
  *
  * Provides a generic storage buffer ring for exceptions
  */

--- a/fsw/shared/inc/cfe_psp_exceptionstorage_types.h
+++ b/fsw/shared/inc/cfe_psp_exceptionstorage_types.h
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_psp_exceptionstorage_types.h
+ * \file
  *
  * Provides a generic storage buffer ring for exceptions
  */

--- a/fsw/shared/inc/cfe_psp_module.h
+++ b/fsw/shared/inc/cfe_psp_module.h
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_psp_module.h
+ * \file
  *
  *  Created on: Jul 17, 2015
  *      Author: joseph.p.hickey@nasa.gov

--- a/fsw/shared/src/cfe_psp_module.c
+++ b/fsw/shared/src/cfe_psp_module.c
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_psp_module.c
+ * \file
  *
  *  Created on: Jul 25, 2014
  *      Author: jphickey

--- a/fsw/shared/src/cfe_psp_version.c
+++ b/fsw/shared/src/cfe_psp_version.c
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_psp_version.c
+ * \file
  *
  * Defines API that obtains the values of the various version identifiers
  */

--- a/unit-test-coverage/mcp750-vxworks/adaptors/inc/ut-adaptor-bootrec.h
+++ b/unit-test-coverage/mcp750-vxworks/adaptors/inc/ut-adaptor-bootrec.h
@@ -11,7 +11,7 @@
  */
 
 /**
- * \file     ut-adaptor-bootrec.h
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/unit-test-coverage/mcp750-vxworks/adaptors/src/ut-adaptor-bootrec.c
+++ b/unit-test-coverage/mcp750-vxworks/adaptors/src/ut-adaptor-bootrec.c
@@ -11,7 +11,7 @@
  */
 
 /**
- * \file     ut-adaptor-bootrec.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/unit-test-coverage/mcp750-vxworks/src/coveragetest-cfe-psp-start.c
+++ b/unit-test-coverage/mcp750-vxworks/src/coveragetest-cfe-psp-start.c
@@ -11,7 +11,7 @@
  */
 
 /**
- * \file     coveragetest-binsem.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/unit-test-coverage/mcp750-vxworks/src/coveragetest-cfe-psp-support.c
+++ b/unit-test-coverage/mcp750-vxworks/src/coveragetest-cfe-psp-support.c
@@ -11,7 +11,7 @@
  */
 
 /**
- * \file     coveragetest-binsem.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/unit-test-coverage/mcp750-vxworks/src/coveragetest-psp-mcp750-vxworks.c
+++ b/unit-test-coverage/mcp750-vxworks/src/coveragetest-psp-mcp750-vxworks.c
@@ -11,7 +11,7 @@
  */
 
 /**
- * \file     coveragetest-binsem.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/unit-test-coverage/mcp750-vxworks/src/coveragetest-psp-mcp750-vxworks.h
+++ b/unit-test-coverage/mcp750-vxworks/src/coveragetest-psp-mcp750-vxworks.h
@@ -11,7 +11,7 @@
  */
 
 /**
- * \file     psp-mcp750-vxworks-coveragetest.h
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/unit-test-coverage/modules/timebase_vxworks/inc/coveragetest-timebase_vxworks.h
+++ b/unit-test-coverage/modules/timebase_vxworks/inc/coveragetest-timebase_vxworks.h
@@ -11,7 +11,7 @@
  */
 
 /**
- * \file     psp-shared-coveragetest.h
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/unit-test-coverage/shared/adaptors/inc/ut-adaptor-exceptions.h
+++ b/unit-test-coverage/shared/adaptors/inc/ut-adaptor-exceptions.h
@@ -11,7 +11,7 @@
  */
 
 /**
- * \file     ut-adaptor-exceptions.h
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/unit-test-coverage/shared/adaptors/src/ut-adaptor-exceptions.c
+++ b/unit-test-coverage/shared/adaptors/src/ut-adaptor-exceptions.c
@@ -11,7 +11,7 @@
  */
 
 /**
- * \file     ut-adaptor-exceptions.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/unit-test-coverage/shared/inc/coveragetest-psp-shared.h
+++ b/unit-test-coverage/shared/inc/coveragetest-psp-shared.h
@@ -11,7 +11,7 @@
  */
 
 /**
- * \file     psp-shared-coveragetest.h
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/unit-test-coverage/shared/src/coveragetest-cfe-psp-exceptionstorage.c
+++ b/unit-test-coverage/shared/src/coveragetest-cfe-psp-exceptionstorage.c
@@ -11,7 +11,7 @@
  */
 
 /**
- * \file     coveragetest-binsem.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/unit-test-coverage/ut-stubs/inc/PCS_vxWorks.h
+++ b/unit-test-coverage/ut-stubs/inc/PCS_vxWorks.h
@@ -11,7 +11,7 @@
  */
 
 /**
- * \file     PCS_vxWorks.h
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  * PSP coverage stub replacement for vxWorks.h

--- a/unit-test-coverage/ut-stubs/override_inc/vxWorks.h
+++ b/unit-test-coverage/ut-stubs/override_inc/vxWorks.h
@@ -11,7 +11,7 @@
  */
 
 /**
- * \file     vxWorks.h
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *


### PR DESCRIPTION
**Describe the contribution**
- Fix #323

**Testing performed**
Make doc, observe no filename warnings

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: i5/wsl
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC