### PR TITLE
Fix #342, Resolve uninit var static analysis warning

### DIFF
--- a/fsw/pc-linux/src/cfe_psp_start.c
+++ b/fsw/pc-linux/src/cfe_psp_start.c
@@ -153,6 +153,8 @@ int32 CFE_PSP_OS_EventHandler(OS_Event_t event, osal_id_t object_id, void *data)
 {
     char taskname[OS_MAX_API_NAME];
 
+    memset(taskname, 0, sizeof(taskname));
+
     switch (event)
     {
         case OS_EVENT_RESOURCE_ALLOCATED:

--- a/unit-test-coverage/modules/timebase_vxworks/src/coveragetest-timebase_vxworks.c
+++ b/unit-test-coverage/modules/timebase_vxworks/src/coveragetest-timebase_vxworks.c
@@ -82,6 +82,8 @@ void Test_Nominal(void)
     OS_time_t                 OsTime;
     PSP_VxWorks_TimeBaseVal_t VxTime;
 
+    memset(&OsTime, 0, sizeof(OsTime));
+
     /* Nominal test with a simple 1:1 ratio */
     UT_PSP_TIMEBASE_VXWORKS_TESTCONFIG.PeriodNumerator   = 1;
     UT_PSP_TIMEBASE_VXWORKS_TESTCONFIG.PeriodDenominator = 1;
@@ -102,6 +104,8 @@ void Test_Non_Reducible(void)
     OS_time_t                 OsTime;
     PSP_VxWorks_TimeBaseVal_t VxTime;
     int64                     TestTime;
+
+    memset(&OsTime, 0, sizeof(OsTime));
 
     /* Use an oddball ratio of of some primes, will not be reducible */
     /* Ratio is 43*3 / 53*2  => 129/106 */
@@ -136,6 +140,8 @@ void Test_Reducible_1(void)
     PSP_VxWorks_TimeBaseVal_t VxTime;
     int64                     TestTime;
 
+    memset(&OsTime, 0, sizeof(OsTime));
+
     /* Test with a ratio that is also 1:1, but can be reduced */
     UT_PSP_TIMEBASE_VXWORKS_TESTCONFIG.PeriodNumerator   = 1000;
     UT_PSP_TIMEBASE_VXWORKS_TESTCONFIG.PeriodDenominator = 1000;
@@ -163,6 +169,8 @@ void Test_Reducible_2(void)
     OS_time_t                 OsTime;
     PSP_VxWorks_TimeBaseVal_t VxTime;
     int64                     TestTime;
+
+    memset(&OsTime, 0, sizeof(OsTime));
 
     /* Test with a ratio that can be reduced */
     /* Final reduced ratio should be 12:5 with 100ns OS ticks */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #342

**Testing performed**
CI + static analysis run

**Expected behavior changes**
None, just squashes static analysis warnings

**System(s) tested on**
 - Hardware: VM
 - OS: Ubuntu 18.04
 - Versions: Bundle main + apps + related static analysis resolution branches

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC