### PR TITLE
Fix #357, Remove unnecessary parentheses around return values.

### DIFF
--- a/fsw/mcp750-vxworks/src/bsp-integration/cfeSupport.c
+++ b/fsw/mcp750-vxworks/src/bsp-integration/cfeSupport.c
@@ -95,7 +95,7 @@ int startCfeCore(char *cfevolume, char *cfepath)
     if (cfevolume == NULL || cfepath == NULL)
     {
         printf("Error: No cFE volume or path/filename given.\n");
-        return (-1);
+        return -1;
     }
 
     /*
@@ -113,7 +113,7 @@ int startCfeCore(char *cfevolume, char *cfepath)
     if (fd < 0)
     {
         printf("Error: Cannot open cFE core file: %s!\n", cfeCorePath);
-        return (-1);
+        return -1;
     }
     else
     {
@@ -128,7 +128,7 @@ int startCfeCore(char *cfevolume, char *cfepath)
     {
         printf("Error: Cannot load cFE core module.\n");
         close(fd);
-        return (-1);
+        return -1;
     }
     else
     {
@@ -151,7 +151,7 @@ int startCfeCore(char *cfevolume, char *cfepath)
         if (status == ERROR)
         {
             printf("Error: Cannot locate CFE_PSP_Main or OS_BSPMain symbols.\n");
-            return (-1);
+            return -1;
         }
     }
 
@@ -164,7 +164,7 @@ int startCfeCore(char *cfevolume, char *cfepath)
     /*
     ** Return to the vxWorks shell
     */
-    return (0);
+    return 0;
 }
 
 /******************************************************************************
@@ -248,5 +248,5 @@ int CFE_PSP_InitFlashDisk(void)
 
     } /* end if */
 
-    return (Status);
+    return Status;
 }

--- a/fsw/mcp750-vxworks/src/cfe_psp_memory.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_memory.c
@@ -106,7 +106,7 @@ int32 CFE_PSP_GetCDSSize(uint32 *SizeOfCDS)
         *SizeOfCDS  = CFE_PSP_ReservedMemoryMap.CDSMemory.BlockSize;
         return_code = CFE_PSP_SUCCESS;
     }
-    return (return_code);
+    return return_code;
 }
 
 /******************************************************************************
@@ -148,7 +148,7 @@ int32 CFE_PSP_WriteToCDS(const void *PtrToDataToWrite, uint32 CDSOffset, uint32 
 
     } /* end if PtrToDataToWrite == NULL */
 
-    return (return_code);
+    return return_code;
 }
 
 /******************************************************************************
@@ -191,7 +191,7 @@ int32 CFE_PSP_ReadFromCDS(void *PtrToDataToRead, uint32 CDSOffset, uint32 NumByt
 
     } /* end if PtrToDataToWrite == NULL */
 
-    return (return_code);
+    return return_code;
 }
 
 /*
@@ -229,7 +229,7 @@ int32 CFE_PSP_GetResetArea(cpuaddr *PtrToResetArea, uint32 *SizeOfResetArea)
         return_code      = CFE_PSP_SUCCESS;
     }
 
-    return (return_code);
+    return return_code;
 }
 
 /*
@@ -266,7 +266,7 @@ int32 CFE_PSP_GetUserReservedArea(cpuaddr *PtrToUserArea, uint32 *SizeOfUserArea
         return_code     = CFE_PSP_SUCCESS;
     }
 
-    return (return_code);
+    return return_code;
 }
 
 /*
@@ -303,7 +303,7 @@ int32 CFE_PSP_GetVolatileDiskMem(cpuaddr *PtrToVolDisk, uint32 *SizeOfVolDisk)
         return_code    = CFE_PSP_SUCCESS;
     }
 
-    return (return_code);
+    return return_code;
 }
 
 /*
@@ -339,7 +339,7 @@ int32 CFE_PSP_InitProcessorReservedMemory(uint32 RestartType)
         CFE_PSP_ReservedMemoryMap.BootPtr->bsp_reset_type = CFE_PSP_RST_TYPE_PROCESSOR;
     }
     return_code = CFE_PSP_SUCCESS;
-    return (return_code);
+    return return_code;
 }
 
 /******************************************************************************
@@ -466,7 +466,7 @@ int32 CFE_PSP_GetKernelTextSegmentInfo(cpuaddr *PtrToKernelSegment, uint32 *Size
         return_code = CFE_PSP_SUCCESS;
     }
 
-    return (return_code);
+    return return_code;
 }
 
 /******************************************************************************
@@ -548,5 +548,5 @@ int32 CFE_PSP_GetCFETextSegmentInfo(cpuaddr *PtrToCFESegment, uint32 *SizeOfCFES
         }
     }
 
-    return (return_code);
+    return return_code;
 }

--- a/fsw/mcp750-vxworks/src/cfe_psp_ssr.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_ssr.c
@@ -91,5 +91,5 @@ int32 CFE_PSP_InitSSR(uint32 bus, uint32 device, char *DeviceName)
         ReturnCode = CFE_PSP_SUCCESS;
     }
 
-    return (ReturnCode);
+    return ReturnCode;
 }

--- a/fsw/mcp750-vxworks/src/cfe_psp_watchdog.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_watchdog.c
@@ -191,7 +191,7 @@ void CFE_PSP_WatchdogService(void)
 */
 uint32 CFE_PSP_WatchdogGet(void)
 {
-    return (CFE_PSP_WatchdogValue);
+    return CFE_PSP_WatchdogValue;
 }
 
 /******************************************************************************

--- a/fsw/modules/eeprom_direct/cfe_psp_eeprom_direct.c
+++ b/fsw/modules/eeprom_direct/cfe_psp_eeprom_direct.c
@@ -78,13 +78,13 @@ int32 CFE_PSP_EepromWrite32(cpuaddr MemoryAddress, uint32 uint32Value)
     /* check 32 bit alignment  */
     if (MemoryAddress & 0x00000003)
     {
-        return (CFE_PSP_ERROR_ADDRESS_MISALIGNED);
+        return CFE_PSP_ERROR_ADDRESS_MISALIGNED;
     }
 
     /* make the Write */
     *((uint32 *)MemoryAddress) = uint32Value;
 
-    return (ret_value);
+    return ret_value;
 }
 
 /*
@@ -119,7 +119,7 @@ int32 CFE_PSP_EepromWrite16(cpuaddr MemoryAddress, uint16 uint16Value)
     */
     if (MemoryAddress & 0x00000001)
     {
-        return (CFE_PSP_ERROR_ADDRESS_MISALIGNED);
+        return CFE_PSP_ERROR_ADDRESS_MISALIGNED;
     }
 
     temp32 = uint16Value;
@@ -179,7 +179,7 @@ int32 CFE_PSP_EepromWrite16(cpuaddr MemoryAddress, uint16 uint16Value)
     }
 #endif
 
-    return (CFE_PSP_EepromWrite32(aligned_address, write32));
+    return CFE_PSP_EepromWrite32(aligned_address, write32);
 }
 
 /*
@@ -264,7 +264,7 @@ int32 CFE_PSP_EepromWrite8(cpuaddr MemoryAddress, uint8 ByteValue)
 
 #endif
 
-    return (CFE_PSP_EepromWrite16(aligned_address, write16));
+    return CFE_PSP_EepromWrite16(aligned_address, write16);
 }
 
 /*
@@ -288,7 +288,7 @@ int32 CFE_PSP_EepromWrite8(cpuaddr MemoryAddress, uint8 ByteValue)
 */
 int32 CFE_PSP_EepromWriteEnable(uint32 Bank)
 {
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 /*
@@ -312,7 +312,7 @@ int32 CFE_PSP_EepromWriteEnable(uint32 Bank)
 */
 int32 CFE_PSP_EepromWriteDisable(uint32 Bank)
 {
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 /*
@@ -335,7 +335,7 @@ int32 CFE_PSP_EepromWriteDisable(uint32 Bank)
 */
 int32 CFE_PSP_EepromPowerUp(uint32 Bank)
 {
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 /*
@@ -358,5 +358,5 @@ int32 CFE_PSP_EepromPowerUp(uint32 Bank)
 */
 int32 CFE_PSP_EepromPowerDown(uint32 Bank)
 {
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }

--- a/fsw/modules/eeprom_mmap_file/cfe_psp_eeprom_mmap_file.c
+++ b/fsw/modules/eeprom_mmap_file/cfe_psp_eeprom_mmap_file.c
@@ -67,7 +67,7 @@ int32 CFE_PSP_SetupEEPROM(uint32 EEPROMSize, cpuaddr *EEPROMAddress)
         if (FileDescriptor == -1)
         {
             OS_printf("CFE_PSP: Cannot open EEPROM File: %s\n", EEPROM_FILE);
-            return (-1);
+            return -1;
         }
         else
         {
@@ -78,7 +78,7 @@ int32 CFE_PSP_SetupEEPROM(uint32 EEPROMSize, cpuaddr *EEPROMAddress)
             {
                 OS_printf("CFE_PSP: Cannot Seek to end of EEPROM file.\n");
                 close(FileDescriptor);
-                return (-1);
+                return -1;
             }
 
             /*
@@ -88,7 +88,7 @@ int32 CFE_PSP_SetupEEPROM(uint32 EEPROMSize, cpuaddr *EEPROMAddress)
             {
                 OS_printf("CFE_PSP: Cannot write to EEPROM file\n");
                 close(FileDescriptor);
-                return (-1);
+                return -1;
             }
         }
     }
@@ -102,7 +102,7 @@ int32 CFE_PSP_SetupEEPROM(uint32 EEPROMSize, cpuaddr *EEPROMAddress)
         {
             OS_printf("CFE_PSP: Cannot open EEPROM File: %s\n", EEPROM_FILE);
             perror("CFE_PSP: open");
-            return (-1);
+            return -1;
         }
     }
 
@@ -113,7 +113,7 @@ int32 CFE_PSP_SetupEEPROM(uint32 EEPROMSize, cpuaddr *EEPROMAddress)
     {
         OS_printf("CFE_PSP: mmap to EEPROM File failed\n");
         close(FileDescriptor);
-        return (-1);
+        return -1;
     }
 
     /*
@@ -121,7 +121,7 @@ int32 CFE_PSP_SetupEEPROM(uint32 EEPROMSize, cpuaddr *EEPROMAddress)
     */
     *EEPROMAddress = (cpuaddr)DataBuffer;
 
-    return (0);
+    return 0;
 }
 
 /* For read/write - As this is mmap'ed we dereference the pointer directly.
@@ -131,39 +131,39 @@ int32 CFE_PSP_SetupEEPROM(uint32 EEPROMSize, cpuaddr *EEPROMAddress)
 int32 CFE_PSP_EepromWrite32(cpuaddr MemoryAddress, uint32 uint32Value)
 {
     *((uint32 *)MemoryAddress) = uint32Value;
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 int32 CFE_PSP_EepromWrite16(cpuaddr MemoryAddress, uint16 uint16Value)
 {
     *((uint16 *)MemoryAddress) = uint16Value;
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 int32 CFE_PSP_EepromWrite8(cpuaddr MemoryAddress, uint8 ByteValue)
 {
     *((uint8 *)MemoryAddress) = ByteValue;
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 int32 CFE_PSP_EepromWriteEnable(uint32 Bank)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 int32 CFE_PSP_EepromWriteDisable(uint32 Bank)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 int32 CFE_PSP_EepromPowerUp(uint32 Bank)
 {
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 int32 CFE_PSP_EepromPowerDown(uint32 Bank)
 {
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 void eeprom_mmap_file_Init(uint32 PspModuleId)

--- a/fsw/modules/eeprom_notimpl/cfe_psp_eeprom_notimpl.c
+++ b/fsw/modules/eeprom_notimpl/cfe_psp_eeprom_notimpl.c
@@ -38,35 +38,35 @@ void eeprom_notimpl_Init(uint32 PspModuleId)
 
 int32 CFE_PSP_EepromWrite32(cpuaddr MemoryAddress, uint32 uint32Value)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 int32 CFE_PSP_EepromWrite16(cpuaddr MemoryAddress, uint16 uint16Value)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 int32 CFE_PSP_EepromWrite8(cpuaddr MemoryAddress, uint8 ByteValue)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 int32 CFE_PSP_EepromWriteEnable(uint32 Bank)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 int32 CFE_PSP_EepromWriteDisable(uint32 Bank)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 int32 CFE_PSP_EepromPowerUp(uint32 Bank)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 int32 CFE_PSP_EepromPowerDown(uint32 Bank)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }

--- a/fsw/modules/port_direct/cfe_psp_port_direct.c
+++ b/fsw/modules/port_direct/cfe_psp_port_direct.c
@@ -63,7 +63,7 @@ int32 CFE_PSP_PortRead8(cpuaddr PortAddress, uint8 *ByteValue)
 
     (*ByteValue) = (uint8) * ((uint8 *)PortAddress);
 
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 /*
@@ -90,7 +90,7 @@ int32 CFE_PSP_PortRead8(cpuaddr PortAddress, uint8 *ByteValue)
 int32 CFE_PSP_PortWrite8(cpuaddr PortAddress, uint8 ByteValue)
 {
     *((uint8 *)PortAddress) = ByteValue;
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 /*
@@ -121,10 +121,10 @@ int32 CFE_PSP_PortRead16(cpuaddr PortAddress, uint16 *uint16Value)
     /* check 16 bit alignment  , check the 1st lsb */
     if (PortAddress & 0x00000001)
     {
-        return (CFE_PSP_ERROR_ADDRESS_MISALIGNED);
+        return CFE_PSP_ERROR_ADDRESS_MISALIGNED;
     }
     (*uint16Value) = *((uint16 *)PortAddress);
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 /*
@@ -155,10 +155,10 @@ int32 CFE_PSP_PortWrite16(cpuaddr PortAddress, uint16 uint16Value)
     /* check 16 bit alignment  , check the 1st lsb */
     if (PortAddress & 0x00000001)
     {
-        return (CFE_PSP_ERROR_ADDRESS_MISALIGNED);
+        return CFE_PSP_ERROR_ADDRESS_MISALIGNED;
     }
     *((uint16 *)PortAddress) = uint16Value;
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 /*
@@ -189,10 +189,10 @@ int32 CFE_PSP_PortRead32(cpuaddr PortAddress, uint32 *uint32Value)
     /* check 32 bit alignment  */
     if (PortAddress & 0x00000003)
     {
-        return (CFE_PSP_ERROR_ADDRESS_MISALIGNED);
+        return CFE_PSP_ERROR_ADDRESS_MISALIGNED;
     }
     (*uint32Value) = *((uint32 *)PortAddress);
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 /*
@@ -223,8 +223,8 @@ int32 CFE_PSP_PortWrite32(cpuaddr PortAddress, uint32 uint32Value)
     /* check 32 bit alignment  */
     if (PortAddress & 0x00000003)
     {
-        return (CFE_PSP_ERROR_ADDRESS_MISALIGNED);
+        return CFE_PSP_ERROR_ADDRESS_MISALIGNED;
     }
     *((uint32 *)PortAddress) = uint32Value;
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }

--- a/fsw/modules/port_notimpl/cfe_psp_port_notimpl.c
+++ b/fsw/modules/port_notimpl/cfe_psp_port_notimpl.c
@@ -38,30 +38,30 @@ void port_notimpl_Init(uint32 PspModuleId)
 
 int32 CFE_PSP_PortRead8(cpuaddr PortAddress, uint8 *ByteValue)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 int32 CFE_PSP_PortWrite8(cpuaddr PortAddress, uint8 ByteValue)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 int32 CFE_PSP_PortRead16(cpuaddr PortAddress, uint16 *uint16Value)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 int32 CFE_PSP_PortWrite16(cpuaddr PortAddress, uint16 uint16Value)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 int32 CFE_PSP_PortRead32(cpuaddr PortAddress, uint32 *uint32Value)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 int32 CFE_PSP_PortWrite32(cpuaddr PortAddress, uint32 uint32Value)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }

--- a/fsw/modules/ram_direct/cfe_psp_ram_direct.c
+++ b/fsw/modules/ram_direct/cfe_psp_ram_direct.c
@@ -62,7 +62,7 @@ int32 CFE_PSP_MemRead8(cpuaddr MemoryAddress, uint8 *ByteValue)
 
     (*ByteValue) = *((uint8 *)MemoryAddress);
 
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 /*
@@ -88,7 +88,7 @@ int32 CFE_PSP_MemRead8(cpuaddr MemoryAddress, uint8 *ByteValue)
 int32 CFE_PSP_MemWrite8(cpuaddr MemoryAddress, uint8 ByteValue)
 {
     *((uint8 *)MemoryAddress) = ByteValue;
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 /*
@@ -119,10 +119,10 @@ int32 CFE_PSP_MemRead16(cpuaddr MemoryAddress, uint16 *uint16Value)
     /* check 16 bit alignment  , check the 1st lsb */
     if (MemoryAddress & 0x00000001)
     {
-        return (CFE_PSP_ERROR_ADDRESS_MISALIGNED);
+        return CFE_PSP_ERROR_ADDRESS_MISALIGNED;
     }
     (*uint16Value) = *((uint16 *)MemoryAddress);
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 /*
  ** Name: CFE_PSP_MemWrite16
@@ -152,10 +152,10 @@ int32 CFE_PSP_MemWrite16(cpuaddr MemoryAddress, uint16 uint16Value)
     /* check 16 bit alignment  , check the 1st lsb */
     if (MemoryAddress & 0x00000001)
     {
-        return (CFE_PSP_ERROR_ADDRESS_MISALIGNED);
+        return CFE_PSP_ERROR_ADDRESS_MISALIGNED;
     }
     *((uint16 *)MemoryAddress) = uint16Value;
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 /*
  ** Name: CFE_PSP_MemRead32
@@ -185,11 +185,11 @@ int32 CFE_PSP_MemRead32(cpuaddr MemoryAddress, uint32 *uint32Value)
     /* check 32 bit alignment  */
     if (MemoryAddress & 0x00000003)
     {
-        return (CFE_PSP_ERROR_ADDRESS_MISALIGNED);
+        return CFE_PSP_ERROR_ADDRESS_MISALIGNED;
     }
     (*uint32Value) = *((uint32 *)MemoryAddress);
 
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 /*
@@ -221,10 +221,10 @@ int32 CFE_PSP_MemWrite32(cpuaddr MemoryAddress, uint32 uint32Value)
     /* check 32 bit alignment  */
     if (MemoryAddress & 0x00000003)
     {
-        return (CFE_PSP_ERROR_ADDRESS_MISALIGNED);
+        return CFE_PSP_ERROR_ADDRESS_MISALIGNED;
     }
 
     *((uint32 *)MemoryAddress) = uint32Value;
 
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }

--- a/fsw/modules/ram_notimpl/cfe_psp_ram_notimpl.c
+++ b/fsw/modules/ram_notimpl/cfe_psp_ram_notimpl.c
@@ -38,30 +38,30 @@ void ram_notimpl_Init(uint32 PspModuleId)
 
 int32 CFE_PSP_MemRead8(cpuaddr MemoryAddress, uint8 *ByteValue)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 int32 CFE_PSP_MemWrite8(cpuaddr MemoryAddress, uint8 ByteValue)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 int32 CFE_PSP_MemRead16(cpuaddr MemoryAddress, uint16 *uint16Value)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 int32 CFE_PSP_MemWrite16(cpuaddr MemoryAddress, uint16 uint16Value)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 int32 CFE_PSP_MemRead32(cpuaddr MemoryAddress, uint32 *uint32Value)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 int32 CFE_PSP_MemWrite32(cpuaddr MemoryAddress, uint32 uint32Value)
 {
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }

--- a/fsw/pc-linux/src/cfe_psp_memory.c
+++ b/fsw/pc-linux/src/cfe_psp_memory.c
@@ -224,7 +224,7 @@ int32 CFE_PSP_GetCDSSize(uint32 *SizeOfCDS)
         return_code = CFE_PSP_SUCCESS;
     }
 
-    return (return_code);
+    return return_code;
 }
 
 /******************************************************************************
@@ -266,7 +266,7 @@ int32 CFE_PSP_WriteToCDS(const void *PtrToDataToWrite, uint32 CDSOffset, uint32 
 
     } /* end if PtrToDataToWrite == NULL */
 
-    return (return_code);
+    return return_code;
 }
 
 /******************************************************************************
@@ -308,7 +308,7 @@ int32 CFE_PSP_ReadFromCDS(void *PtrToDataToRead, uint32 CDSOffset, uint32 NumByt
 
     } /* end if PtrToDataToWrite == NULL */
 
-    return (return_code);
+    return return_code;
 }
 
 /*
@@ -451,7 +451,7 @@ int32 CFE_PSP_GetResetArea(cpuaddr *PtrToResetArea, uint32 *SizeOfResetArea)
         return_code      = CFE_PSP_SUCCESS;
     }
 
-    return (return_code);
+    return return_code;
 }
 
 /*
@@ -566,7 +566,7 @@ int32 CFE_PSP_GetUserReservedArea(cpuaddr *PtrToUserArea, uint32 *SizeOfUserArea
         return_code     = CFE_PSP_SUCCESS;
     }
 
-    return (return_code);
+    return return_code;
 }
 
 /*
@@ -625,7 +625,7 @@ int32 CFE_PSP_GetVolatileDiskMem(cpuaddr *PtrToVolDisk, uint32 *SizeOfVolDisk)
         return_code    = CFE_PSP_SUCCESS;
     }
 
-    return (return_code);
+    return return_code;
 }
 
 /*
@@ -732,7 +732,7 @@ int32 CFE_PSP_InitProcessorReservedMemory(uint32 RestartType)
      */
     CFE_PSP_ReservedMemoryMap.BootPtr->ValidityFlag = CFE_PSP_BOOTRECORD_INVALID;
 
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 /******************************************************************************
@@ -782,10 +782,10 @@ int32 CFE_PSP_GetKernelTextSegmentInfo(cpuaddr *PtrToKernelSegment, uint32 *Size
     */
     if (PtrToKernelSegment == NULL || SizeOfKernelSegment == NULL)
     {
-        return (CFE_PSP_ERROR);
+        return CFE_PSP_ERROR;
     }
 
-    return (CFE_PSP_ERROR_NOT_IMPLEMENTED);
+    return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }
 
 /******************************************************************************
@@ -817,5 +817,5 @@ int32 CFE_PSP_GetCFETextSegmentInfo(cpuaddr *PtrToCFESegment, uint32 *SizeOfCFES
         return_code = CFE_PSP_SUCCESS;
     }
 
-    return (return_code);
+    return return_code;
 }

--- a/fsw/pc-linux/src/cfe_psp_ssr.c
+++ b/fsw/pc-linux/src/cfe_psp_ssr.c
@@ -67,5 +67,5 @@ int32 CFE_PSP_InitSSR(uint32 bus, uint32 device, char *DeviceName)
 
     Status = CFE_PSP_ERROR;
 
-    return (Status);
+    return Status;
 }

--- a/fsw/pc-linux/src/cfe_psp_support.c
+++ b/fsw/pc-linux/src/cfe_psp_support.c
@@ -172,7 +172,7 @@ void CFE_PSP_FlushCaches(uint32 type, void *address, uint32 size)
 */
 uint32 CFE_PSP_GetProcessorId(void)
 {
-    return (CFE_PSP_CpuId);
+    return CFE_PSP_CpuId;
 }
 
 /*
@@ -192,7 +192,7 @@ uint32 CFE_PSP_GetProcessorId(void)
 */
 uint32 CFE_PSP_GetSpacecraftId(void)
 {
-    return (CFE_PSP_SpacecraftId);
+    return CFE_PSP_SpacecraftId;
 }
 
 /*
@@ -212,5 +212,5 @@ uint32 CFE_PSP_GetSpacecraftId(void)
 */
 const char *CFE_PSP_GetProcessorName(void)
 {
-    return (CFE_PSP_CpuName);
+    return CFE_PSP_CpuName;
 }

--- a/fsw/pc-linux/src/cfe_psp_watchdog.c
+++ b/fsw/pc-linux/src/cfe_psp_watchdog.c
@@ -139,7 +139,7 @@ void CFE_PSP_WatchdogService(void) {}
 */
 uint32 CFE_PSP_WatchdogGet(void)
 {
-    return (CFE_PSP_WatchdogValue);
+    return CFE_PSP_WatchdogValue;
 }
 
 /******************************************************************************

--- a/fsw/pc-rtems/src/cfe_psp_memory.c
+++ b/fsw/pc-rtems/src/cfe_psp_memory.c
@@ -119,7 +119,7 @@ int32 CFE_PSP_GetCDSSize(uint32 *SizeOfCDS)
         *SizeOfCDS  = CFE_PSP_ReservedMemoryMap.CDSMemory.BlockSize;
         return_code = OS_SUCCESS;
     }
-    return (return_code);
+    return return_code;
 }
 
 /******************************************************************************
@@ -161,7 +161,7 @@ int32 CFE_PSP_WriteToCDS(const void *PtrToDataToWrite, uint32 CDSOffset, uint32 
 
     } /* end if PtrToDataToWrite == NULL */
 
-    return (return_code);
+    return return_code;
 }
 
 /******************************************************************************
@@ -204,7 +204,7 @@ int32 CFE_PSP_ReadFromCDS(void *PtrToDataToRead, uint32 CDSOffset, uint32 NumByt
 
     } /* end if PtrToDataToWrite == NULL */
 
-    return (return_code);
+    return return_code;
 }
 
 /*
@@ -242,7 +242,7 @@ int32 CFE_PSP_GetResetArea(cpuaddr *PtrToResetArea, uint32 *SizeOfResetArea)
         return_code      = OS_SUCCESS;
     }
 
-    return (return_code);
+    return return_code;
 }
 
 /*
@@ -279,7 +279,7 @@ int32 CFE_PSP_GetUserReservedArea(cpuaddr *PtrToUserArea, uint32 *SizeOfUserArea
         return_code     = OS_SUCCESS;
     }
 
-    return (return_code);
+    return return_code;
 }
 
 /*
@@ -316,7 +316,7 @@ int32 CFE_PSP_GetVolatileDiskMem(cpuaddr *PtrToVolDisk, uint32 *SizeOfVolDisk)
         return_code    = OS_SUCCESS;
     }
 
-    return (return_code);
+    return return_code;
 }
 
 /*
@@ -489,7 +489,7 @@ int32 CFE_PSP_GetKernelTextSegmentInfo(cpuaddr *PtrToKernelSegment, uint32 *Size
         return_code = OS_SUCCESS;
     }
 
-    return (return_code);
+    return return_code;
 }
 
 /******************************************************************************
@@ -531,5 +531,5 @@ int32 CFE_PSP_GetCFETextSegmentInfo(cpuaddr *PtrToCFESegment, uint32 *SizeOfCFES
         return_code = OS_SUCCESS;
     }
 
-    return (return_code);
+    return return_code;
 }

--- a/fsw/pc-rtems/src/cfe_psp_ssr.c
+++ b/fsw/pc-rtems/src/cfe_psp_ssr.c
@@ -68,5 +68,5 @@ int32 CFE_PSP_InitSSR(uint32 bus, uint32 device, char *DeviceName)
 
     ReturnCode = CFE_PSP_SUCCESS;
 
-    return (ReturnCode);
+    return ReturnCode;
 }

--- a/fsw/pc-rtems/src/cfe_psp_support.c
+++ b/fsw/pc-rtems/src/cfe_psp_support.c
@@ -147,7 +147,7 @@ void CFE_PSP_FlushCaches(uint32 type, void *address, uint32 size)
 */
 uint32 CFE_PSP_GetProcessorId(void)
 {
-    return (CFE_PSP_CPU_ID);
+    return CFE_PSP_CPU_ID;
 }
 
 /*
@@ -167,7 +167,7 @@ uint32 CFE_PSP_GetProcessorId(void)
 */
 uint32 CFE_PSP_GetSpacecraftId(void)
 {
-    return (CFE_PSP_SPACECRAFT_ID);
+    return CFE_PSP_SPACECRAFT_ID;
 }
 
 /*
@@ -187,5 +187,5 @@ uint32 CFE_PSP_GetSpacecraftId(void)
 */
 const char *CFE_PSP_GetProcessorName(void)
 {
-    return (CFE_PSP_CPU_NAME);
+    return CFE_PSP_CPU_NAME;
 }

--- a/fsw/pc-rtems/src/cfe_psp_watchdog.c
+++ b/fsw/pc-rtems/src/cfe_psp_watchdog.c
@@ -139,7 +139,7 @@ void CFE_PSP_WatchdogService(void) {}
 */
 uint32 CFE_PSP_WatchdogGet(void)
 {
-    return (CFE_PSP_WatchdogValue);
+    return CFE_PSP_WatchdogValue;
 }
 
 /******************************************************************************

--- a/fsw/shared/src/cfe_psp_memrange.c
+++ b/fsw/shared/src/cfe_psp_memrange.c
@@ -77,12 +77,12 @@ int32 CFE_PSP_MemValidateRange(cpuaddr Address, size_t Size, uint32 MemoryType)
     */
     if (MemoryType != CFE_PSP_MEM_ANY && MemoryType != CFE_PSP_MEM_RAM && MemoryType != CFE_PSP_MEM_EEPROM)
     {
-        return (CFE_PSP_INVALID_MEM_TYPE);
+        return CFE_PSP_INVALID_MEM_TYPE;
     }
 
     if (EndAddressToTest < StartAddressToTest)
     {
-        return (CFE_PSP_INVALID_MEM_RANGE);
+        return CFE_PSP_INVALID_MEM_RANGE;
     }
 
     SysMemPtr = CFE_PSP_ReservedMemoryMap.SysMemoryTable;
@@ -150,7 +150,7 @@ int32 CFE_PSP_MemValidateRange(cpuaddr Address, size_t Size, uint32 MemoryType)
         ++SysMemPtr;
 
     } /* End for */
-    return (ReturnCode);
+    return ReturnCode;
 }
 
 /*
@@ -173,7 +173,7 @@ int32 CFE_PSP_MemValidateRange(cpuaddr Address, size_t Size, uint32 MemoryType)
 */
 uint32 CFE_PSP_MemRanges(void)
 {
-    return (CFE_PSP_MEM_TABLE_SIZE);
+    return CFE_PSP_MEM_TABLE_SIZE;
 }
 
 /*
@@ -219,24 +219,24 @@ int32 CFE_PSP_MemRangeSet(uint32 RangeNum, uint32 MemoryType, cpuaddr StartAddr,
 
     if (RangeNum >= CFE_PSP_MEM_TABLE_SIZE)
     {
-        return (CFE_PSP_INVALID_MEM_RANGE);
+        return CFE_PSP_INVALID_MEM_RANGE;
     }
 
     if ((MemoryType != CFE_PSP_MEM_RAM) && (MemoryType != CFE_PSP_MEM_EEPROM))
     {
-        return (CFE_PSP_INVALID_MEM_TYPE);
+        return CFE_PSP_INVALID_MEM_TYPE;
     }
 
     if ((WordSize != CFE_PSP_MEM_SIZE_BYTE) && (WordSize != CFE_PSP_MEM_SIZE_WORD) &&
         (WordSize != CFE_PSP_MEM_SIZE_DWORD))
     {
-        return (CFE_PSP_INVALID_MEM_WORDSIZE);
+        return CFE_PSP_INVALID_MEM_WORDSIZE;
     }
 
     if ((Attributes != CFE_PSP_MEM_ATTR_READ) && (Attributes != CFE_PSP_MEM_ATTR_WRITE) &&
         (Attributes != CFE_PSP_MEM_ATTR_READWRITE))
     {
-        return (CFE_PSP_INVALID_MEM_ATTR);
+        return CFE_PSP_INVALID_MEM_ATTR;
     }
 
     /*
@@ -250,7 +250,7 @@ int32 CFE_PSP_MemRangeSet(uint32 RangeNum, uint32 MemoryType, cpuaddr StartAddr,
     SysMemPtr->WordSize   = WordSize;
     SysMemPtr->Attributes = Attributes;
 
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 /*
@@ -291,12 +291,12 @@ int32 CFE_PSP_MemRangeGet(uint32 RangeNum, uint32 *MemoryType, cpuaddr *StartAdd
 
     if (MemoryType == NULL || StartAddr == NULL || Size == NULL || WordSize == NULL || Attributes == NULL)
     {
-        return (CFE_PSP_INVALID_POINTER);
+        return CFE_PSP_INVALID_POINTER;
     }
 
     if (RangeNum >= CFE_PSP_MEM_TABLE_SIZE)
     {
-        return (CFE_PSP_INVALID_MEM_RANGE);
+        return CFE_PSP_INVALID_MEM_RANGE;
     }
 
     SysMemPtr = &CFE_PSP_ReservedMemoryMap.SysMemoryTable[RangeNum];
@@ -307,5 +307,5 @@ int32 CFE_PSP_MemRangeGet(uint32 RangeNum, uint32 *MemoryType, cpuaddr *StartAdd
     *WordSize   = SysMemPtr->WordSize;
     *Attributes = SysMemPtr->Attributes;
 
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }

--- a/fsw/shared/src/cfe_psp_memutils.c
+++ b/fsw/shared/src/cfe_psp_memutils.c
@@ -70,7 +70,7 @@
 int32 CFE_PSP_MemCpy(void *dst, const void *src, uint32 size)
 {
     memcpy(dst, src, size);
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }
 
 /*
@@ -100,5 +100,5 @@ int32 CFE_PSP_MemCpy(void *dst, const void *src, uint32 size)
 int32 CFE_PSP_MemSet(void *dst, uint8 value, uint32 size)
 {
     memset(dst, (int)value, (size_t)size);
-    return (CFE_PSP_SUCCESS);
+    return CFE_PSP_SUCCESS;
 }

--- a/unit-test-coverage/ut-stubs/src/libc-stdlib-stubs.c
+++ b/unit-test-coverage/ut-stubs/src/libc-stdlib-stubs.c
@@ -153,7 +153,7 @@ void *PCS_malloc(size_t sz)
     Rec->Magic     = MPOOL_BLOCK_SIGNATURE;
     Rec->Size      = sz;
 
-    return ((void *)NextBlock);
+    return (void *)NextBlock;
 }
 
 void PCS_free(void *ptr)

--- a/unit-test-coverage/ut-stubs/src/vxworks-sysLib-stubs.c
+++ b/unit-test-coverage/ut-stubs/src/vxworks-sysLib-stubs.c
@@ -25,7 +25,7 @@
 
 int PCS_sysClkRateGet(void)
 {
-    return (UT_DEFAULT_IMPL_RC(PCS_sysClkRateGet, 10000));
+    return UT_DEFAULT_IMPL_RC(PCS_sysClkRateGet, 10000);
 }
 char *PCS_sysMemTop(void)
 {
@@ -61,10 +61,10 @@ void PCS_sysPciRead32(uint32_t address, uint32_t *data)
 
 unsigned int PCS_GetWrsKernelTextStart(void)
 {
-    return (UT_DEFAULT_IMPL(PCS_GetWrsKernelTextStart));
+    return UT_DEFAULT_IMPL(PCS_GetWrsKernelTextStart);
 }
 
 unsigned int PCS_GetWrsKernelTextEnd(void)
 {
-    return (UT_DEFAULT_IMPL(PCS_GetWrsKernelTextEnd));
+    return UT_DEFAULT_IMPL(PCS_GetWrsKernelTextEnd);
 }

--- a/unit-test-coverage/ut-stubs/src/vxworks-taskLib-stubs.c
+++ b/unit-test-coverage/ut-stubs/src/vxworks-taskLib-stubs.c
@@ -51,7 +51,7 @@ PCS_TASK_ID PCS_taskIdSelf(void)
     Status = UT_DEFAULT_IMPL(PCS_taskIdSelf);
     if (Status != 0)
     {
-        return ((PCS_TASK_ID)PCS_ERROR);
+        return (PCS_TASK_ID)PCS_ERROR;
     }
 
     return &PCS_LOCAL_TASK;
@@ -63,41 +63,41 @@ PCS_TASK_ID PCS_taskNameToId(const char *name)
     Status = UT_DEFAULT_IMPL(PCS_taskNameToId);
     if (Status != 0)
     {
-        return ((PCS_TASK_ID)PCS_ERROR);
+        return (PCS_TASK_ID)PCS_ERROR;
     }
 
     return &PCS_LOCAL_TASK;
 }
 PCS_STATUS PCS_taskDelay(int ticks)
 {
-    return (UT_DEFAULT_IMPL(PCS_taskDelay));
+    return UT_DEFAULT_IMPL(PCS_taskDelay);
 }
 PCS_STATUS PCS_taskDelete(PCS_TASK_ID tid)
 {
-    return (UT_DEFAULT_IMPL(PCS_taskDelete));
+    return UT_DEFAULT_IMPL(PCS_taskDelete);
 }
 PCS_STATUS PCS_taskDeleteForce(PCS_TASK_ID tid)
 {
-    return (UT_DEFAULT_IMPL(PCS_taskDeleteForce));
+    return UT_DEFAULT_IMPL(PCS_taskDeleteForce);
 }
 PCS_STATUS PCS_taskSuspend(PCS_TASK_ID tid)
 {
-    return (UT_DEFAULT_IMPL(PCS_taskSuspend));
+    return UT_DEFAULT_IMPL(PCS_taskSuspend);
 }
 PCS_STATUS PCS_taskResume(PCS_TASK_ID tid)
 {
-    return (UT_DEFAULT_IMPL(PCS_taskResume));
+    return UT_DEFAULT_IMPL(PCS_taskResume);
 }
 PCS_STATUS PCS_taskPrioritySet(PCS_TASK_ID tid, int newPriority)
 {
-    return (UT_DEFAULT_IMPL(PCS_taskPrioritySet));
+    return UT_DEFAULT_IMPL(PCS_taskPrioritySet);
 }
 
 PCS_STATUS PCS_taskInit(PCS_WIND_TCB *pTcb, char *name, int priority, int options, char *pStackBase, int stackSize,
                         PCS_FUNCPTR entryPt, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7,
                         int arg8, int arg9, int arg10)
 {
-    return (UT_DEFAULT_IMPL(PCS_taskInit));
+    return UT_DEFAULT_IMPL(PCS_taskInit);
 }
 
 PCS_TASK_ID PCS_taskSpawn(char *name, int priority, int options, int stackSize, PCS_FUNCPTR entryPt, int arg1, int arg2,
@@ -109,7 +109,7 @@ PCS_TASK_ID PCS_taskSpawn(char *name, int priority, int options, int stackSize, 
     Status = UT_DEFAULT_IMPL(PCS_taskSpawn);
     if (Status != 0)
     {
-        return ((PCS_TASK_ID)PCS_ERROR);
+        return (PCS_TASK_ID)PCS_ERROR;
     }
 
     return &PCS_LOCAL_TASK;
@@ -132,7 +132,7 @@ PCS_WIND_TCB *PCS_taskTcb(PCS_TASK_ID tid)
     Status = UT_DEFAULT_IMPL(PCS_taskTcb);
     if (Status != 0)
     {
-        return (NULL);
+        return NULL;
     }
 
     if (UT_Stub_CopyToLocal(UT_KEY(PCS_taskTcb), &LocalTcb, sizeof(LocalTcb)) < sizeof(LocalTcb))


### PR DESCRIPTION
**Checklist (Please check before submitting)**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #357  
Removes parentheses in return statements in PSP that return a single value/term.
This is aligns these return statements with the predominant style of cFS.

**Testing performed**
None, prior to submission of the pull request.

**Expected behavior changes**
No impact on behavior.

**Contributor Info - All information REQUIRED for consideration of pull request**
@thnkslprpt 