### PR TITLE
Fix #364, Stop empty function catching CI workflow format checks

### DIFF
--- a/fsw/pc-rtems/src/cfe_psp_exception.c
+++ b/fsw/pc-rtems/src/cfe_psp_exception.c
@@ -91,6 +91,4 @@ int32 CFE_PSP_ExceptionGetSummary_Impl(const CFE_PSP_Exception_LogData_t *Buffer
 **   Notes: The exception environment is local to each task Therefore this must be
 **          called for each task that that wants to do floating point and catch exceptions
 */
-void CFE_PSP_SetDefaultExceptionEnvironment(void)
-{
-}
+void CFE_PSP_SetDefaultExceptionEnvironment(void) {}


### PR DESCRIPTION
**Checklist (Please check before submitting)**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Quick fix of #364

**Testing performed**
None

**Expected behavior changes**
Empty function will stop catching up workflow check and causing its failure.

**Contributor Info - All information REQUIRED for consideration of pull request**
@thnkslprpt 