### PR TITLE
Fix #367, Remove redundant/inconsistent comments (/* end of function */, /* end if */ etc.) and clean up empty lines.

### DIFF
--- a/fsw/mcp750-vxworks/inc/cfe_psp_config.h
+++ b/fsw/mcp750-vxworks/inc/cfe_psp_config.h
@@ -83,7 +83,6 @@ typedef struct
     uint32 spare1;
     uint32 spare2;
     uint32 spare3;
-
 } CFE_PSP_ReservedMemoryBootRecord_t;
 
 /**
@@ -101,7 +100,6 @@ typedef struct
     int        vector;         /* vector number */
     ESFPPC     esf;            /* Exception stack frame */
     FP_CONTEXT fp;             /* floating point registers */
-
 } CFE_PSP_Exception_ContextDataEntry_t;
 
 /*

--- a/fsw/mcp750-vxworks/src/bsp-integration/cfeSupport.c
+++ b/fsw/mcp750-vxworks/src/bsp-integration/cfeSupport.c
@@ -58,7 +58,6 @@ extern SYMTAB_ID sysSymTbl;
 extern int DriveNum;
 
 /*
-** Function: GetWrsKernelTextStart
 ** Purpose:  This function returns the start address of the kernel code.
 **
 */
@@ -68,7 +67,6 @@ unsigned int GetWrsKernelTextStart(void)
 }
 
 /*
-** Function: GetWrsKernelTextEnd
 ** Purpose:  This function returns the end address of the kernel code.
 **
 */
@@ -78,7 +76,6 @@ unsigned int GetWrsKernelTextEnd(void)
 }
 
 /*
-** Function: loadCfeCore
 ** Purpose:  This function unzips ( if needed ) , loads, and starts the cFE core.
 **
 */
@@ -168,7 +165,6 @@ int startCfeCore(char *cfevolume, char *cfepath)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_InitFlashDisk()
 **
 **  Purpose:
 **    Initialize the Compact flash disk in vxWorks

--- a/fsw/mcp750-vxworks/src/cfe_psp_exception.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_exception.c
@@ -72,8 +72,6 @@ void CFE_PSP_ExceptionHook(TASK_ID task_id, int vector, void *vpEsf);
 
 /*
 **
-**   Name: CFE_PSP_AttachExceptions
-**
 **   Purpose: This function Initializes the task exceptions and adds a hook
 **              into the VxWorks exception handling.  The below hook is called
 **              for every exception that VxWorks catches.
@@ -92,7 +90,6 @@ void CFE_PSP_AttachExceptions(void)
 }
 
 /*
-** Name: CFE_PSP_ExceptionHook
 **
 ** Purpose: Make the proper call to CFE_ES_EXCEPTION_FUNCTION (defined in
 **          cfe_es_platform.cfg)
@@ -153,12 +150,9 @@ void CFE_PSP_ExceptionHook(TASK_ID task_id, int vector, void *vpEsf)
         /* notify the CFE of the event */
         GLOBAL_CFE_CONFIGDATA.SystemNotify();
     }
-
-} /* end function */
+}
 
 /*
-**
-**   Name: CFE_PSP_SetDefaultExceptionEnvironment
 **
 **   Purpose: This function sets a default exception environment that can be used
 **
@@ -184,8 +178,6 @@ void CFE_PSP_SetDefaultExceptionEnvironment(void)
 }
 
 /*
- * Name: CFE_PSP_ExceptionGetSummary_Impl
- *
  * Purpose: Translate a stored exception log entry into a summary string
  */
 int32 CFE_PSP_ExceptionGetSummary_Impl(const CFE_PSP_Exception_LogData_t *Buffer, char *ReasonBuf, uint32 ReasonSize)

--- a/fsw/mcp750-vxworks/src/cfe_psp_memory.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_memory.c
@@ -81,7 +81,6 @@ CFE_PSP_MemoryBlock_t MCP750_ReservedMemBlock;
 */
 
 /******************************************************************************
-**  Function: CFE_PSP_GetCDSSize
 **
 **  Purpose:
 **    This function fetches the size of the OS Critical Data Store area.
@@ -110,7 +109,6 @@ int32 CFE_PSP_GetCDSSize(uint32 *SizeOfCDS)
 }
 
 /******************************************************************************
-**  Function: CFE_PSP_WriteToCDS
 **
 **  Purpose:
 **    This function writes to the CDS Block.
@@ -152,7 +150,6 @@ int32 CFE_PSP_WriteToCDS(const void *PtrToDataToWrite, uint32 CDSOffset, uint32 
 }
 
 /******************************************************************************
-**  Function: CFE_PSP_ReadFromCDS
 **
 **  Purpose:
 **   This function reads from the CDS Block
@@ -201,7 +198,6 @@ int32 CFE_PSP_ReadFromCDS(void *PtrToDataToRead, uint32 CDSOffset, uint32 NumByt
 */
 
 /******************************************************************************
-**  Function: CFE_PSP_GetResetArea
 **
 **  Purpose:
 **     This function returns the location and size of the ES Reset information area.
@@ -239,7 +235,6 @@ int32 CFE_PSP_GetResetArea(cpuaddr *PtrToResetArea, uint32 *SizeOfResetArea)
 */
 
 /******************************************************************************
-**  Function: CFE_PSP_GetUserReservedArea
 **
 **  Purpose:
 **    This function returns the location and size of the memory used for the cFE
@@ -276,7 +271,6 @@ int32 CFE_PSP_GetUserReservedArea(cpuaddr *PtrToUserArea, uint32 *SizeOfUserArea
 */
 
 /******************************************************************************
-**  Function: CFE_PSP_GetVolatileDiskMem
 **
 **  Purpose:
 **    This function returns the location and size of the memory used for the cFE
@@ -313,7 +307,6 @@ int32 CFE_PSP_GetVolatileDiskMem(cpuaddr *PtrToVolDisk, uint32 *SizeOfVolDisk)
 */
 
 /******************************************************************************
-**  Function: CFE_PSP_InitProcessorReservedMemory
 **
 **  Purpose:
 **    This function performs the top level reserved memory initialization.
@@ -343,7 +336,6 @@ int32 CFE_PSP_InitProcessorReservedMemory(uint32 RestartType)
 }
 
 /******************************************************************************
-**  Function: CFE_PSP_SetupReservedMemoryMap
 **
 **  Purpose:
 **    Set up the CFE_PSP_ReservedMemoryMap global data structure
@@ -414,7 +406,6 @@ void CFE_PSP_SetupReservedMemoryMap(void)
 }
 
 /******************************************************************************
- * Function: CFE_PSP_DeleteProcessorReservedMemory
  *
  * No action on MCP750 - reserved block is statically allocated at sysMemTop.
  * Implemented for API consistency with other PSPs.
@@ -428,7 +419,6 @@ void CFE_PSP_DeleteProcessorReservedMemory(void) {}
 */
 
 /******************************************************************************
-**  Function: CFE_PSP_GetKernelTextSegmentInfo
 **
 **  Purpose:
 **    This function returns the start and end address of the kernel text segment.
@@ -470,7 +460,6 @@ int32 CFE_PSP_GetKernelTextSegmentInfo(cpuaddr *PtrToKernelSegment, uint32 *Size
 }
 
 /******************************************************************************
-**  Function: CFE_PSP_GetCFETextSegmentInfo
 **
 **  Purpose:
 **    This function returns the start and end address of the CFE text segment.

--- a/fsw/mcp750-vxworks/src/cfe_psp_ssr.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_ssr.c
@@ -61,7 +61,6 @@
 #include "cfe_psp_memory.h"
 
 /******************************************************************************
-**  Function:  CFE_PSP_InitSSR
 **
 **  Purpose:
 **    Initializes the Solid State Recorder device. For the MCP750, this simply

--- a/fsw/mcp750-vxworks/src/cfe_psp_start.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_start.c
@@ -75,7 +75,6 @@ IMPORT void sysPciWrite32(UINT32, UINT32);
 #define CFE_PSP_NONVOL_STARTUP_FILE (GLOBAL_CONFIGDATA.CfeConfig->NonvolStartupFile)
 
 /******************************************************************************
-**  Function:  OS_Application_Startup()
 **
 **  Purpose:
 **    Application startup entry point from OSAL BSP.
@@ -187,7 +186,6 @@ void OS_Application_Startup(void)
     }
     else if (reset_register & SYS_REG_BLRR_SWHRST)
     {
-
         /*
         ** For a Software hard reset, we want to look at the special
         ** BSP reset variable to determine if we wanted a

--- a/fsw/mcp750-vxworks/src/cfe_psp_support.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_support.c
@@ -72,7 +72,6 @@
 extern CFE_PSP_MemoryBlock_t MCP750_ReservedMemBlock;
 
 /******************************************************************************
-**  Function:  CFE_PSP_Restart()
 **
 **  Purpose:
 **    Provides a common interface to the processor reset.
@@ -86,7 +85,6 @@ extern CFE_PSP_MemoryBlock_t MCP750_ReservedMemBlock;
 
 void CFE_PSP_Restart(uint32 reset_type)
 {
-
     if (reset_type == CFE_PSP_RST_TYPE_POWERON)
     {
         CFE_PSP_ReservedMemoryMap.BootPtr->bsp_reset_type = CFE_PSP_RST_TYPE_POWERON;
@@ -102,7 +100,6 @@ void CFE_PSP_Restart(uint32 reset_type)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_Panic()
 **
 **  Purpose:
 **    Provides a common interface to abort the cFE startup process and return
@@ -122,7 +119,6 @@ void CFE_PSP_Panic(int32 ErrorCode)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_FlushCaches()
 **
 **  Purpose:
 **    Provides a common interface to flush the processor caches. This routine
@@ -144,7 +140,6 @@ void CFE_PSP_FlushCaches(uint32 type, void *address, uint32 size)
 }
 
 /*
-** Name: CFE_PSP_GetProcessorId
 **
 ** Purpose:
 **         return the processor ID.
@@ -166,7 +161,6 @@ uint32 CFE_PSP_GetProcessorId(void)
 }
 
 /*
-** Name: CFE_PSP_GetSpacecraftId
 **
 ** Purpose:
 **         return the spacecraft ID.
@@ -186,7 +180,6 @@ uint32 CFE_PSP_GetSpacecraftId(void)
 }
 
 /*
-** Name: CFE_PSP_GetProcessorName
 **
 ** Purpose:
 **         return the processor name.

--- a/fsw/mcp750-vxworks/src/cfe_psp_watchdog.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_watchdog.c
@@ -72,7 +72,7 @@
 */
 uint32 CFE_PSP_WatchdogValue = CFE_PSP_WATCHDOG_MAX;
 
-/*  Function:  CFE_PSP_WatchdogInit()
+/******************************************************************************
 **
 **  Purpose:
 **    To setup the timer resolution and/or other settings custom to this platform.
@@ -83,7 +83,6 @@ uint32 CFE_PSP_WatchdogValue = CFE_PSP_WATCHDOG_MAX;
 */
 void CFE_PSP_WatchdogInit(void)
 {
-
     /*
     ** Just set it to a value right now
     ** The pc-linux desktop platform does not actually implement a watchdog
@@ -93,7 +92,6 @@ void CFE_PSP_WatchdogInit(void)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_WatchdogEnable()
 **
 **  Purpose:
 **    Enable the watchdog timer
@@ -112,7 +110,6 @@ void CFE_PSP_WatchdogEnable(void)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_WatchdogDisable()
 **
 **  Purpose:
 **    Disable the watchdog timer
@@ -131,7 +128,6 @@ void CFE_PSP_WatchdogDisable(void)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_WatchdogService()
 **
 **  Purpose:
 **    Load the watchdog timer with a count that corresponds to the millisecond
@@ -174,8 +170,8 @@ void CFE_PSP_WatchdogService(void)
         PCI_OUT_LONG(0xFEFF0068, 0xFFFFFFAA);
     }
 }
+
 /******************************************************************************
-**  Function:  CFE_PSP_WatchdogGet
 **
 **  Purpose:
 **    Get the current watchdog value.
@@ -195,7 +191,6 @@ uint32 CFE_PSP_WatchdogGet(void)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_WatchdogSet
 **
 **  Purpose:
 **    Get the current watchdog value.

--- a/fsw/modules/eeprom_direct/cfe_psp_eeprom_direct.c
+++ b/fsw/modules/eeprom_direct/cfe_psp_eeprom_direct.c
@@ -51,7 +51,6 @@ void eeprom_direct_Init(uint32 PspModuleId)
 */
 
 /*
- ** Name: CFE_PSP_EepromWrite32
  **
  ** Purpose:
  **
@@ -88,7 +87,6 @@ int32 CFE_PSP_EepromWrite32(cpuaddr MemoryAddress, uint32 uint32Value)
 }
 
 /*
- ** Name: CFE_PSP_EepromWrite16
  **
  ** Purpose:
  **
@@ -183,7 +181,6 @@ int32 CFE_PSP_EepromWrite16(cpuaddr MemoryAddress, uint16 uint16Value)
 }
 
 /*
- ** Name: CFE_PSP_EepromWrite8
  **
  ** Purpose:
  **
@@ -268,7 +265,6 @@ int32 CFE_PSP_EepromWrite8(cpuaddr MemoryAddress, uint8 ByteValue)
 }
 
 /*
-** Name: CFE_PSP_EepromWriteEnable
 **
 ** Purpose:
 **		Enable the eeprom for write operation
@@ -292,7 +288,6 @@ int32 CFE_PSP_EepromWriteEnable(uint32 Bank)
 }
 
 /*
-** Name: CFE_PSP_EepromWriteDisable
 **
 ** Purpose:
 **		Disable  the eeprom from write operation
@@ -316,7 +311,6 @@ int32 CFE_PSP_EepromWriteDisable(uint32 Bank)
 }
 
 /*
-** Name: CFE_PSP_EepromPowerUp
 **
 ** Purpose:
 **		Power up the eeprom
@@ -339,7 +333,6 @@ int32 CFE_PSP_EepromPowerUp(uint32 Bank)
 }
 
 /*
-** Name: CFE_PSP_EepromPowerDown
 **
 ** Purpose:
 **		Power down the eeprom

--- a/fsw/modules/eeprom_mmap_file/cfe_psp_eeprom_mmap_file.c
+++ b/fsw/modules/eeprom_mmap_file/cfe_psp_eeprom_mmap_file.c
@@ -46,7 +46,6 @@ CFE_PSP_MODULE_DECLARE_SIMPLE(eeprom_mmap_file);
 */
 int32 CFE_PSP_SetupEEPROM(uint32 EEPROMSize, cpuaddr *EEPROMAddress)
 {
-
     int         FileDescriptor;
     int         ReturnStatus;
     char *      DataBuffer;

--- a/fsw/modules/port_direct/cfe_psp_port_direct.c
+++ b/fsw/modules/port_direct/cfe_psp_port_direct.c
@@ -39,7 +39,6 @@ void port_direct_Init(uint32 PspModuleId)
 */
 
 /*
-** Name: CFE_PSP_PortRead8
 **
 ** Purpose:
 **         Read one byte of memory.
@@ -60,14 +59,12 @@ void port_direct_Init(uint32 PspModuleId)
 */
 int32 CFE_PSP_PortRead8(cpuaddr PortAddress, uint8 *ByteValue)
 {
-
     (*ByteValue) = (uint8) * ((uint8 *)PortAddress);
 
     return CFE_PSP_SUCCESS;
 }
 
 /*
-** Name: CFE_PSP_PortWrite8
 **
 ** Purpose:
 **         Write one byte of memory.
@@ -94,7 +91,6 @@ int32 CFE_PSP_PortWrite8(cpuaddr PortAddress, uint8 ByteValue)
 }
 
 /*
-** Name: CFE_PSP_PortRead16
 **
 ** Purpose:
 **         Read  2 bytes of memory.
@@ -128,7 +124,6 @@ int32 CFE_PSP_PortRead16(cpuaddr PortAddress, uint16 *uint16Value)
 }
 
 /*
-** Name: CFE_PSP_PortWrite16
 **
 ** Purpose:
 **         Write 2 byte of memory.
@@ -162,7 +157,6 @@ int32 CFE_PSP_PortWrite16(cpuaddr PortAddress, uint16 uint16Value)
 }
 
 /*
-** Name: CFE_PSP_PortRead32
 **
 ** Purpose:
 **         Read 4 bytes of memory.
@@ -196,7 +190,6 @@ int32 CFE_PSP_PortRead32(cpuaddr PortAddress, uint32 *uint32Value)
 }
 
 /*
-** Name: CFE_PSP_PortWrite32
 **
 ** Purpose:
 **         Write 4 byte of memory.

--- a/fsw/modules/ram_direct/cfe_psp_ram_direct.c
+++ b/fsw/modules/ram_direct/cfe_psp_ram_direct.c
@@ -39,7 +39,6 @@ void ram_direct_Init(uint32 PspModuleId)
 */
 
 /*
- ** Name: CFE_PSP_MemRead8
  **
  ** Purpose:
  **         Read one byte of memory.
@@ -59,14 +58,12 @@ void ram_direct_Init(uint32 PspModuleId)
  */
 int32 CFE_PSP_MemRead8(cpuaddr MemoryAddress, uint8 *ByteValue)
 {
-
     (*ByteValue) = *((uint8 *)MemoryAddress);
 
     return CFE_PSP_SUCCESS;
 }
 
 /*
- ** Name: CFE_PSP_MemWrite8
  **
  ** Purpose:
  **         Write one byte of memory.
@@ -92,7 +89,6 @@ int32 CFE_PSP_MemWrite8(cpuaddr MemoryAddress, uint8 ByteValue)
 }
 
 /*
- ** Name: CFE_PSP_MemRead16
  **
  ** Purpose:
  **         Read  2 bytes of memory.
@@ -124,8 +120,8 @@ int32 CFE_PSP_MemRead16(cpuaddr MemoryAddress, uint16 *uint16Value)
     (*uint16Value) = *((uint16 *)MemoryAddress);
     return CFE_PSP_SUCCESS;
 }
+
 /*
- ** Name: CFE_PSP_MemWrite16
  **
  ** Purpose:
  **         Write 2 byte of memory.
@@ -157,8 +153,8 @@ int32 CFE_PSP_MemWrite16(cpuaddr MemoryAddress, uint16 uint16Value)
     *((uint16 *)MemoryAddress) = uint16Value;
     return CFE_PSP_SUCCESS;
 }
+
 /*
- ** Name: CFE_PSP_MemRead32
  **
  ** Purpose:
  **         Read 4 bytes of memory.
@@ -193,7 +189,6 @@ int32 CFE_PSP_MemRead32(cpuaddr MemoryAddress, uint32 *uint32Value)
 }
 
 /*
- ** Name: CFE_PSP_MemWrite32
  **
  ** Purpose:
  **         Write 4 byte of memory.
@@ -217,7 +212,6 @@ int32 CFE_PSP_MemRead32(cpuaddr MemoryAddress, uint32 *uint32Value)
  */
 int32 CFE_PSP_MemWrite32(cpuaddr MemoryAddress, uint32 uint32Value)
 {
-
     /* check 32 bit alignment  */
     if (MemoryAddress & 0x00000003)
     {

--- a/fsw/modules/timebase_posix_clock/cfe_psp_timebase_posix_clock.c
+++ b/fsw/modules/timebase_posix_clock/cfe_psp_timebase_posix_clock.c
@@ -116,7 +116,6 @@ void CFE_PSP_GetTime(OS_time_t *LocalTime)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_GetTimerTicksPerSecond()
 **
 **  Purpose:
 **    Provides the resolution of the least significant 32 bits of the 64 bit
@@ -137,7 +136,6 @@ uint32 CFE_PSP_GetTimerTicksPerSecond(void)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_GetTimerLow32Rollover()
 **
 **  Purpose:
 **    Provides the number that the least significant 32 bits of the 64 bit

--- a/fsw/modules/timebase_vxworks/cfe_psp_timebase_vxworks.c
+++ b/fsw/modules/timebase_vxworks/cfe_psp_timebase_vxworks.c
@@ -144,7 +144,6 @@ void timebase_vxworks_Init(uint32 PspModuleId)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_GetTimerTicksPerSecond()
 **
 **  Purpose:
 **    Provides the resolution of the least significant 32 bits of the 64 bit
@@ -164,7 +163,6 @@ uint32 CFE_PSP_GetTimerTicksPerSecond(void)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_GetTimerLow32Rollover()
 **
 **  Purpose:
 **    Provides the number that the least significant 32 bits of the 64 bit
@@ -185,7 +183,6 @@ uint32 CFE_PSP_GetTimerLow32Rollover(void)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_Get_Timebase()
 **
 **  Purpose:
 **    Provides a common interface to system timebase. This routine
@@ -203,7 +200,6 @@ void CFE_PSP_Get_Timebase(uint32 *Tbu, uint32 *Tbl)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_GetTime()
 **
 **  Purpose: Gets the value of the timebase from the hardware normalized as OS_time_t
 **
@@ -244,5 +240,4 @@ void CFE_PSP_GetTime(OS_time_t *LocalTime)
 
     /* Output the value as an OS_time_t */
     *LocalTime = (OS_time_t) {NormalizedTicks};
-
-} /* end CFE_PSP_GetLocalTime */
+}

--- a/fsw/pc-linux/inc/cfe_psp_config.h
+++ b/fsw/pc-linux/inc/cfe_psp_config.h
@@ -88,7 +88,6 @@ typedef struct
 {
     uint32 ValidityFlag;
     uint32 NextResetType;
-
 } CFE_PSP_ReservedMemoryBootRecord_t;
 
 /*

--- a/fsw/pc-linux/src/cfe_psp_exception.c
+++ b/fsw/pc-linux/src/cfe_psp_exception.c
@@ -60,7 +60,6 @@ sigset_t CFE_PSP_AsyncMask;
  ***************************************************************************/
 
 /*
-** Name: CFE_PSP_ExceptionSigHandler
 **
 ** Installed as a signal handler to log exception events.
 **
@@ -111,7 +110,6 @@ void CFE_PSP_ExceptionSigHandler(int signo, siginfo_t *si, void *ctxt)
 }
 
 /*
-** Name: CFE_PSP_ExceptionSigHandlerSuspend
 **
 ** An extension of CFE_PSP_ExceptionSigHandler that also
 ** suspends the calling task and prevents returning to the
@@ -139,8 +137,7 @@ void CFE_PSP_ExceptionSigHandlerSuspend(int signo, siginfo_t *si, void *ctxt)
      * will be deleted by the CFE/OSAL.
      */
     sigsuspend(&CFE_PSP_AsyncMask);
-
-} /* end function */
+}
 
 /*
  * Helper function to call sigaction() to attach a signal handler
@@ -183,7 +180,6 @@ void CFE_PSP_AttachSigHandler(int signo)
 }
 
 /*
-**   Name: CFE_PSP_AttachExceptions
 **
 **   This is called from the CFE Main task, before any other threads
 **   are started.  Use this opportunity to install the handler for
@@ -249,8 +245,6 @@ void CFE_PSP_AttachExceptions(void)
 }
 
 /*
-**
-**   Name: CFE_PSP_SetDefaultExceptionEnvironment
 **
 **   Purpose: This function sets a default exception environment that can be used
 **

--- a/fsw/pc-linux/src/cfe_psp_memory.c
+++ b/fsw/pc-linux/src/cfe_psp_memory.c
@@ -118,7 +118,6 @@ CFE_PSP_ReservedMemoryMap_t CFE_PSP_ReservedMemoryMap;
 **
 */
 /******************************************************************************
-**  Function: CFE_PSP_InitCDS
 **
 **  Purpose: This function is used by the ES startup code to initialize the
 **            Critical Data store area
@@ -167,7 +166,6 @@ void CFE_PSP_InitCDS(void)
 }
 
 /******************************************************************************
-**  Function: CFE_PSP_DeleteCDS
 **
 **  Purpose:
 **   This is an internal function to delete the CDS Shared memory segment.
@@ -180,7 +178,6 @@ void CFE_PSP_InitCDS(void)
 */
 void CFE_PSP_DeleteCDS(void)
 {
-
     int             ReturnCode;
     struct shmid_ds ShmCtrl;
 
@@ -198,7 +195,6 @@ void CFE_PSP_DeleteCDS(void)
 }
 
 /******************************************************************************
-**  Function: CFE_PSP_GetCDSSize
 **
 **  Purpose:
 **    This function fetches the size of the OS Critical Data Store area.
@@ -228,7 +224,6 @@ int32 CFE_PSP_GetCDSSize(uint32 *SizeOfCDS)
 }
 
 /******************************************************************************
-**  Function: CFE_PSP_WriteToCDS
 **
 **  Purpose:
 **    This function writes to the CDS Block.
@@ -270,7 +265,6 @@ int32 CFE_PSP_WriteToCDS(const void *PtrToDataToWrite, uint32 CDSOffset, uint32 
 }
 
 /******************************************************************************
-**  Function: CFE_PSP_ReadFromCDS
 **
 **  Purpose:
 **   This function reads from the CDS Block
@@ -318,7 +312,6 @@ int32 CFE_PSP_ReadFromCDS(void *PtrToDataToRead, uint32 CDSOffset, uint32 NumByt
 */
 
 /******************************************************************************
-**  Function: CFE_PSP_InitESResetArea
 **
 **  Purpose:
 **    This function is used by the ES startup code to initialize the
@@ -332,7 +325,6 @@ int32 CFE_PSP_ReadFromCDS(void *PtrToDataToRead, uint32 CDSOffset, uint32 NumByt
 */
 void CFE_PSP_InitResetArea(void)
 {
-
     key_t                                   key;
     size_t                                  total_size;
     size_t                                  reset_offset;
@@ -391,7 +383,6 @@ void CFE_PSP_InitResetArea(void)
 }
 
 /******************************************************************************
-**  Function: CFE_PSP_DeleteResetArea
 **
 **  Purpose:
 **   This is an internal function to delete the Reset Area Shared memory segment.
@@ -423,7 +414,6 @@ void CFE_PSP_DeleteResetArea(void)
 /*
  */
 /******************************************************************************
-**  Function: CFE_PSP_GetResetArea
 **
 **  Purpose:
 **     This function returns the location and size of the ES Reset information area.
@@ -461,7 +451,6 @@ int32 CFE_PSP_GetResetArea(cpuaddr *PtrToResetArea, uint32 *SizeOfResetArea)
 */
 
 /******************************************************************************
-**  Function: CFE_PSP_InitUserReservedArea
 **
 **  Purpose:
 **    This function is used by the ES startup code to initialize the
@@ -509,7 +498,6 @@ void CFE_PSP_InitUserReservedArea(void)
 }
 
 /******************************************************************************
-**  Function: CFE_PSP_DeleteUserReservedArea
 **
 **  Purpose:
 **   This is an internal function to delete the User Reserved Shared memory segment.
@@ -539,7 +527,6 @@ void CFE_PSP_DeleteUserReservedArea(void)
 }
 
 /******************************************************************************
-**  Function: CFE_PSP_GetUserReservedArea
 **
 **  Purpose:
 **    This function returns the location and size of the memory used for the cFE
@@ -576,7 +563,6 @@ int32 CFE_PSP_GetUserReservedArea(cpuaddr *PtrToUserArea, uint32 *SizeOfUserArea
 */
 
 /******************************************************************************
-**  Function: CFE_PSP_InitVolatileDiskMem
 **
 **  Purpose:
 **   This function is used by the ES startup code to initialize the memory
@@ -598,7 +584,6 @@ void CFE_PSP_InitVolatileDiskMem(void)
 }
 
 /******************************************************************************
-**  Function: CFE_PSP_GetVolatileDiskMem
 **
 **  Purpose:
 **    This function returns the location and size of the memory used for the cFE
@@ -635,7 +620,6 @@ int32 CFE_PSP_GetVolatileDiskMem(cpuaddr *PtrToVolDisk, uint32 *SizeOfVolDisk)
 */
 
 /******************************************************************************
-**  Function: CFE_PSP_InitProcessorReservedMemory
 **
 **  Purpose:
 **    This function performs the top level reserved memory initialization.
@@ -683,7 +667,6 @@ void CFE_PSP_SetupReservedMemoryMap(void)
 
 int32 CFE_PSP_InitProcessorReservedMemory(uint32 RestartType)
 {
-
     /*
      * Clear the segments only on a POWER ON reset
      *
@@ -736,7 +719,6 @@ int32 CFE_PSP_InitProcessorReservedMemory(uint32 RestartType)
 }
 
 /******************************************************************************
-**  Function: CFE_PSP_DeleteProcessorReservedMemory
 **
 **  Purpose:
 **    This function cleans up all of the shared memory segments in the
@@ -750,7 +732,6 @@ int32 CFE_PSP_InitProcessorReservedMemory(uint32 RestartType)
 */
 void CFE_PSP_DeleteProcessorReservedMemory(void)
 {
-
     CFE_PSP_DeleteCDS();
     CFE_PSP_DeleteResetArea();
     CFE_PSP_DeleteUserReservedArea();
@@ -763,7 +744,6 @@ void CFE_PSP_DeleteProcessorReservedMemory(void)
 */
 
 /******************************************************************************
-**  Function: CFE_PSP_GetKernelTextSegmentInfo
 **
 **  Purpose:
 **    This function returns the start and end address of the kernel text segment.
@@ -789,7 +769,6 @@ int32 CFE_PSP_GetKernelTextSegmentInfo(cpuaddr *PtrToKernelSegment, uint32 *Size
 }
 
 /******************************************************************************
-**  Function: CFE_PSP_GetCFETextSegmentInfo
 **
 **  Purpose:
 **    This function returns the start and end address of the CFE text segment.

--- a/fsw/pc-linux/src/cfe_psp_ssr.c
+++ b/fsw/pc-linux/src/cfe_psp_ssr.c
@@ -49,7 +49,6 @@
 #include <unistd.h>
 
 /******************************************************************************
-**  Function:  CFE_PSP_InitSSR
 **
 **  Purpose:
 **    Initializes the Solid State Recorder device. This can be filled in for the platform.

--- a/fsw/pc-linux/src/cfe_psp_start.c
+++ b/fsw/pc-linux/src/cfe_psp_start.c
@@ -105,7 +105,6 @@ typedef struct
 
     uint32 SpacecraftId;    /* Spacecraft ID */
     uint32 GotSpacecraftId; /* Did we get a Spacecraft ID */
-
 } CFE_PSP_CommandData_t;
 
 /*
@@ -142,7 +141,6 @@ static const struct option longOpts[] = {{"reset", required_argument, NULL, 'R'}
                                          {NULL, no_argument, NULL, 0}};
 
 /******************************************************************************
-**  Function:  CFE_PSP_OS_EventHandler()
 **
 **  Purpose:
 **    Linux Task creation event handler.
@@ -211,7 +209,6 @@ int32 CFE_PSP_OS_EventHandler(OS_Event_t event, osal_id_t object_id, void *data)
 }
 
 /******************************************************************************
-**  Function:  main()
 **
 **  Purpose:
 **    BSP Application entry point.
@@ -491,7 +488,6 @@ void OS_Application_Run(void)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_DisplayUsage
 **
 **  Purpose:
 **    Display program usage, and exit.
@@ -504,7 +500,6 @@ void OS_Application_Run(void)
 */
 void CFE_PSP_DisplayUsage(char *Name)
 {
-
     printf("usage : %s [-R <value>] [-S <value>] [-C <value] [-N <value] [-I <value] [-h] \n", Name);
     printf("\n");
     printf("        All parameters are optional and can be used in any order\n");
@@ -538,8 +533,8 @@ void CFE_PSP_DisplayUsage(char *Name)
 
     exit(1);
 }
+
 /******************************************************************************
-**  Function: CFE_PSP_ProcessArgumentDefaults
 **
 **  Purpose:
 **    This function assigns defaults to parameters and checks to make sure

--- a/fsw/pc-linux/src/cfe_psp_support.c
+++ b/fsw/pc-linux/src/cfe_psp_support.c
@@ -52,7 +52,6 @@ extern uint32 CFE_PSP_CpuId;
 extern char   CFE_PSP_CpuName[];
 
 /******************************************************************************
-**  Function:  CFE_PSP_Restart()
 **
 **  Purpose:
 **    Provides a common interface to the processor reset.
@@ -115,7 +114,6 @@ void CFE_PSP_Restart(uint32 reset_type)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_Panic()
 **
 **  Purpose:
 **    Provides a common interface to abort the cFE startup process and return
@@ -136,7 +134,6 @@ void CFE_PSP_Panic(int32 ErrorCode)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_FlushCaches)
 **
 **  Purpose:
 **    Provides a common interface to flush the processor caches. This routine
@@ -154,7 +151,6 @@ void CFE_PSP_FlushCaches(uint32 type, void *address, uint32 size)
 }
 
 /*
-** Name: CFE_PSP_GetProcessorId
 **
 ** Purpose:
 **         return the processor ID.
@@ -176,7 +172,6 @@ uint32 CFE_PSP_GetProcessorId(void)
 }
 
 /*
-** Name: CFE_PSP_GetSpacecraftId
 **
 ** Purpose:
 **         return the spacecraft ID.
@@ -196,7 +191,6 @@ uint32 CFE_PSP_GetSpacecraftId(void)
 }
 
 /*
-** Name: CFE_PSP_GetProcessorName
 **
 ** Purpose:
 **         return the processor name.

--- a/fsw/pc-linux/src/cfe_psp_watchdog.c
+++ b/fsw/pc-linux/src/cfe_psp_watchdog.c
@@ -60,7 +60,7 @@
 */
 uint32 CFE_PSP_WatchdogValue = CFE_PSP_WATCHDOG_MAX;
 
-/*  Function:  CFE_PSP_WatchdogInit()
+/*
 **
 **  Purpose:
 **    To setup the timer resolution and/or other settings custom to this platform.
@@ -71,7 +71,6 @@ uint32 CFE_PSP_WatchdogValue = CFE_PSP_WATCHDOG_MAX;
 */
 void CFE_PSP_WatchdogInit(void)
 {
-
     /*
     ** Just set it to a value right now
     ** The pc-linux desktop platform does not actually implement a watchdog
@@ -81,7 +80,6 @@ void CFE_PSP_WatchdogInit(void)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_WatchdogEnable()
 **
 **  Purpose:
 **    Enable the watchdog timer
@@ -93,7 +91,6 @@ void CFE_PSP_WatchdogInit(void)
 void CFE_PSP_WatchdogEnable(void) {}
 
 /******************************************************************************
-**  Function:  CFE_PSP_WatchdogDisable()
 **
 **  Purpose:
 **    Disable the watchdog timer
@@ -105,7 +102,6 @@ void CFE_PSP_WatchdogEnable(void) {}
 void CFE_PSP_WatchdogDisable(void) {}
 
 /******************************************************************************
-**  Function:  CFE_PSP_WatchdogService()
 **
 **  Purpose:
 **    Load the watchdog timer with a count that corresponds to the millisecond
@@ -123,7 +119,6 @@ void CFE_PSP_WatchdogDisable(void) {}
 void CFE_PSP_WatchdogService(void) {}
 
 /******************************************************************************
-**  Function:  CFE_PSP_WatchdogGet
 **
 **  Purpose:
 **    Get the current watchdog value.
@@ -143,7 +138,6 @@ uint32 CFE_PSP_WatchdogGet(void)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_WatchdogSet
 **
 **  Purpose:
 **    Get the current watchdog value.
@@ -159,6 +153,5 @@ uint32 CFE_PSP_WatchdogGet(void)
 */
 void CFE_PSP_WatchdogSet(uint32 WatchdogValue)
 {
-
     CFE_PSP_WatchdogValue = WatchdogValue;
 }

--- a/fsw/pc-rtems/inc/cfe_psp_config.h
+++ b/fsw/pc-rtems/inc/cfe_psp_config.h
@@ -56,7 +56,6 @@ typedef struct
 {
     /* not currently used in PC-RTEMS */
     uint32 reserved;
-
 } CFE_PSP_ReservedMemoryBootRecord_t;
 
 /**

--- a/fsw/pc-rtems/src/cfe_psp_exception.c
+++ b/fsw/pc-rtems/src/cfe_psp_exception.c
@@ -60,8 +60,6 @@
 
 /*
 **
-**   Name: CFE_PSP_AttachExceptions
-**
 **   Purpose: No-op on this platform, implemented for API compatibility.
 **
 */
@@ -72,8 +70,6 @@ void CFE_PSP_AttachExceptions(void)
 }
 
 /*
- * Name: CFE_PSP_ExceptionGetSummary_Impl
- *
  * Purpose: Translate a stored exception log entry into a summary string
  */
 int32 CFE_PSP_ExceptionGetSummary_Impl(const CFE_PSP_Exception_LogData_t *Buffer, char *ReasonBuf, uint32 ReasonSize)
@@ -84,13 +80,9 @@ int32 CFE_PSP_ExceptionGetSummary_Impl(const CFE_PSP_Exception_LogData_t *Buffer
 
 /*
 **
-**   Name: CFE_PSP_SetDefaultExceptionEnvironment
-**
 **   Purpose: This function sets a default exception environment that can be used
 **
 **   Notes: The exception environment is local to each task Therefore this must be
 **          called for each task that that wants to do floating point and catch exceptions
 */
-void CFE_PSP_SetDefaultExceptionEnvironment(void)
-{
-}
+void CFE_PSP_SetDefaultExceptionEnvironment(void) {}

--- a/fsw/pc-rtems/src/cfe_psp_memory.c
+++ b/fsw/pc-rtems/src/cfe_psp_memory.c
@@ -94,7 +94,6 @@ CFE_PSP_MemoryBlock_t PcRtems_ReservedMemBlock;
 */
 
 /******************************************************************************
-**  Function: CFE_PSP_GetCDSSize
 **
 **  Purpose:
 **    This function fetches the size of the OS Critical Data Store area.
@@ -123,7 +122,6 @@ int32 CFE_PSP_GetCDSSize(uint32 *SizeOfCDS)
 }
 
 /******************************************************************************
-**  Function: CFE_PSP_WriteToCDS
 **
 **  Purpose:
 **    This function writes to the CDS Block.
@@ -165,7 +163,6 @@ int32 CFE_PSP_WriteToCDS(const void *PtrToDataToWrite, uint32 CDSOffset, uint32 
 }
 
 /******************************************************************************
-**  Function: CFE_PSP_ReadFromCDS
 **
 **  Purpose:
 **   This function reads from the CDS Block
@@ -214,7 +211,6 @@ int32 CFE_PSP_ReadFromCDS(void *PtrToDataToRead, uint32 CDSOffset, uint32 NumByt
 */
 
 /******************************************************************************
-**  Function: CFE_PSP_GetResetArea
 **
 **  Purpose:
 **     This function returns the location and size of the ES Reset information area.
@@ -252,7 +248,6 @@ int32 CFE_PSP_GetResetArea(cpuaddr *PtrToResetArea, uint32 *SizeOfResetArea)
 */
 
 /******************************************************************************
-**  Function: CFE_PSP_GetUserReservedArea
 **
 **  Purpose:
 **    This function returns the location and size of the memory used for the cFE
@@ -289,7 +284,6 @@ int32 CFE_PSP_GetUserReservedArea(cpuaddr *PtrToUserArea, uint32 *SizeOfUserArea
 */
 
 /******************************************************************************
-**  Function: CFE_PSP_GetVolatileDiskMem
 **
 **  Purpose:
 **    This function returns the location and size of the memory used for the cFE
@@ -326,7 +320,6 @@ int32 CFE_PSP_GetVolatileDiskMem(cpuaddr *PtrToVolDisk, uint32 *SizeOfVolDisk)
 */
 
 /******************************************************************************
-**  Function: CFE_PSP_SetupReservedMemoryMap
 **
 **  Purpose:
 **    This function performs the top level reserved memory initialization.
@@ -426,7 +419,6 @@ void CFE_PSP_SetupReservedMemoryMap(void)
 }
 
 /******************************************************************************
-**  Function: CFE_PSP_InitProcessorReservedMemory
 **
 **  Purpose:
 **    This function performs the top level reserved memory initialization.
@@ -451,7 +443,6 @@ int32 CFE_PSP_InitProcessorReservedMemory(uint32 RestartType)
 */
 
 /******************************************************************************
-**  Function: CFE_PSP_GetKernelTextSegmentInfo
 **
 **  Purpose:
 **    This function returns the start and end address of the kernel text segment.
@@ -493,7 +484,6 @@ int32 CFE_PSP_GetKernelTextSegmentInfo(cpuaddr *PtrToKernelSegment, uint32 *Size
 }
 
 /******************************************************************************
-**  Function: CFE_PSP_GetCFETextSegmentInfo
 **
 **  Purpose:
 **    This function returns the start and end address of the CFE text segment.

--- a/fsw/pc-rtems/src/cfe_psp_ssr.c
+++ b/fsw/pc-rtems/src/cfe_psp_ssr.c
@@ -48,7 +48,6 @@
 #include "cfe_psp_memory.h"
 
 /******************************************************************************
-**  Function:  CFE_PSP_InitSSR
 **
 **  Purpose:
 **    Initializes the Solid State Recorder device. Dummy function for this

--- a/fsw/pc-rtems/src/cfe_psp_start.c
+++ b/fsw/pc-rtems/src/cfe_psp_start.c
@@ -89,7 +89,6 @@ struct rtems_bsdnet_config rtems_bsdnet_config = {
 int timer_count = 0;
 
 /******************************************************************************
-**  Function:  CFE_PSP_Setup()
 **
 **  Purpose:
 **    Perform initial setup.
@@ -157,7 +156,6 @@ void OS_Application_Startup(void)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_Main()
 **
 **  Purpose:
 **    Application entry point.

--- a/fsw/pc-rtems/src/cfe_psp_support.c
+++ b/fsw/pc-rtems/src/cfe_psp_support.c
@@ -66,7 +66,6 @@
 extern CFE_PSP_MemoryBlock_t PcRtems_ReservedMemBlock;
 
 /******************************************************************************
-**  Function:  CFE_PSP_Restart()
 **
 **  Purpose:
 **    Provides a common interface to the processor reset.
@@ -80,14 +79,12 @@ extern CFE_PSP_MemoryBlock_t PcRtems_ReservedMemBlock;
 
 void CFE_PSP_Restart(uint32 reset_type)
 {
-
     CFE_PSP_FlushCaches(1, PcRtems_ReservedMemBlock.BlockPtr, PcRtems_ReservedMemBlock.BlockSize);
     OS_printf("CFE_PSP_Restart is not implemented on this platform ( yet ! )\n");
     exit(-1);
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_Panic()
 **
 **  Purpose:
 **    Provides a common interface to abort the cFE startup process and return
@@ -107,7 +104,6 @@ void CFE_PSP_Panic(int32 ErrorCode)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_FlushCaches()
 **
 **  Purpose:
 **    Provides a common interface to flush the processor caches. This routine
@@ -129,7 +125,6 @@ void CFE_PSP_FlushCaches(uint32 type, void *address, uint32 size)
 }
 
 /*
-** Name: CFE_PSP_GetProcessorId
 **
 ** Purpose:
 **         return the processor ID.
@@ -151,7 +146,6 @@ uint32 CFE_PSP_GetProcessorId(void)
 }
 
 /*
-** Name: CFE_PSP_GetSpacecraftId
 **
 ** Purpose:
 **         return the spacecraft ID.
@@ -171,7 +165,6 @@ uint32 CFE_PSP_GetSpacecraftId(void)
 }
 
 /*
-** Name: CFE_PSP_GetProcessorName
 **
 ** Purpose:
 **         return the processor name.

--- a/fsw/pc-rtems/src/cfe_psp_watchdog.c
+++ b/fsw/pc-rtems/src/cfe_psp_watchdog.c
@@ -60,7 +60,7 @@
 */
 uint32 CFE_PSP_WatchdogValue = 0;
 
-/*  Function:  CFE_PSP_WatchdogInit()
+/*
 **
 **  Purpose:
 **    To setup the timer resolution and/or other settings custom to this platform.
@@ -71,7 +71,6 @@ uint32 CFE_PSP_WatchdogValue = 0;
 */
 void CFE_PSP_WatchdogInit(void)
 {
-
     /*
     ** Just set it to a value right now
     ** The pc-linux desktop platform does not actually implement a watchdog
@@ -81,7 +80,6 @@ void CFE_PSP_WatchdogInit(void)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_WatchdogEnable()
 **
 **  Purpose:
 **    Enable the watchdog timer
@@ -93,7 +91,6 @@ void CFE_PSP_WatchdogInit(void)
 void CFE_PSP_WatchdogEnable(void) {}
 
 /******************************************************************************
-**  Function:  CFE_PSP_WatchdogDisable()
 **
 **  Purpose:
 **    Disable the watchdog timer
@@ -105,7 +102,6 @@ void CFE_PSP_WatchdogEnable(void) {}
 void CFE_PSP_WatchdogDisable(void) {}
 
 /******************************************************************************
-**  Function:  CFE_PSP_WatchdogService()
 **
 **  Purpose:
 **    Load the watchdog timer with a count that corresponds to the millisecond
@@ -123,7 +119,6 @@ void CFE_PSP_WatchdogDisable(void) {}
 void CFE_PSP_WatchdogService(void) {}
 
 /******************************************************************************
-**  Function:  CFE_PSP_WatchdogGet
 **
 **  Purpose:
 **    Get the current watchdog value.
@@ -143,7 +138,6 @@ uint32 CFE_PSP_WatchdogGet(void)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_WatchdogSet
 **
 **  Purpose:
 **    Get the current watchdog value.
@@ -159,6 +153,5 @@ uint32 CFE_PSP_WatchdogGet(void)
 */
 void CFE_PSP_WatchdogSet(uint32 WatchdogValue)
 {
-
     CFE_PSP_WatchdogValue = WatchdogValue;
 }

--- a/fsw/shared/inc/cfe_psp_memory.h
+++ b/fsw/shared/inc/cfe_psp_memory.h
@@ -54,7 +54,6 @@ typedef struct
 {
     void * BlockPtr;
     size_t BlockSize;
-
 } CFE_PSP_MemoryBlock_t;
 
 typedef struct
@@ -75,7 +74,6 @@ typedef struct
      */
 
     CFE_PSP_MemTable_t SysMemoryTable[CFE_PSP_MEM_TABLE_SIZE];
-
 } CFE_PSP_ReservedMemoryMap_t;
 
 /**

--- a/fsw/shared/src/cfe_psp_error.c
+++ b/fsw/shared/src/cfe_psp_error.c
@@ -27,8 +27,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_PSP_StatusToString
- *
  *  Purpose: Implemented per public PSP API
  *           See description in API and header file for detail
  *

--- a/fsw/shared/src/cfe_psp_memrange.c
+++ b/fsw/shared/src/cfe_psp_memrange.c
@@ -36,7 +36,6 @@
 #include "cfe_psp_memory.h"
 
 /*
-** Name: CFE_PSP_MemValidateRange
 **
 ** Purpose:
 **		Validate the memory range and type using the global CFE_PSP_MemoryTable
@@ -154,7 +153,6 @@ int32 CFE_PSP_MemValidateRange(cpuaddr Address, size_t Size, uint32 MemoryType)
 }
 
 /*
-** Name: CFE_PSP_MemRanges
 **
 ** Purpose:
 **		Return the number of memory ranges in the CFE_PSP_MemoryTable
@@ -177,7 +175,6 @@ uint32 CFE_PSP_MemRanges(void)
 }
 
 /*
-** Name: CFE_PSP_MemRangeSet
 **
 ** Purpose:
 **		This function populates one of the records in the CFE_PSP_MemoryTable.
@@ -254,7 +251,6 @@ int32 CFE_PSP_MemRangeSet(uint32 RangeNum, uint32 MemoryType, cpuaddr StartAddr,
 }
 
 /*
-** Name: CFE_PSP_MemRangeGet
 **
 ** Purpose:
 **		This function retrieves one of the records in the CFE_PSP_MemoryTable.

--- a/fsw/shared/src/cfe_psp_memutils.c
+++ b/fsw/shared/src/cfe_psp_memutils.c
@@ -46,7 +46,6 @@
 */
 
 /*
-** Name: CFE_PSP_MemCpy
 **
 ** Purpose:
 **	Copies 'size' byte from memory address pointed by 'src' to memory
@@ -74,7 +73,6 @@ int32 CFE_PSP_MemCpy(void *dst, const void *src, uint32 size)
 }
 
 /*
-** Name: CFE_PSP_MemSet
 **
 ** Purpose:
 **	Copies 'size' number of byte of value 'value' to memory address pointed

--- a/fsw/shared/src/cfe_psp_module.c
+++ b/fsw/shared/src/cfe_psp_module.c
@@ -54,7 +54,6 @@
 static uint32 CFE_PSP_ConfigPspModuleListLength = 0;
 
 /***************************************************
- * Function Name: CFE_PSP_ModuleInitList
  *
  * Helper function to initialize a list of modules (not externally called)
  * Returns the number of modules initialized
@@ -91,7 +90,6 @@ uint32_t CFE_PSP_ModuleInitList(uint32 BaseId, CFE_StaticModuleLoadEntry_t *List
 }
 
 /***************************************************
- * Function Name: CFE_PSP_ModuleInit
  *
  * See prototype for full description
  */
@@ -106,7 +104,6 @@ void CFE_PSP_ModuleInit(void)
 }
 
 /***************************************************
- * Function Name: CFE_PSP_Module_GetAPIEntry
  *
  * See prototype for full description
  */
@@ -130,7 +127,6 @@ int32 CFE_PSP_Module_GetAPIEntry(uint32 PspModuleId, CFE_PSP_ModuleApi_t **API)
 }
 
 /***************************************************
- * Function Name: CFE_PSP_Module_FindByName
  *
  * See prototype for full description
  */

--- a/fsw/shared/src/cfe_psp_version.c
+++ b/fsw/shared/src/cfe_psp_version.c
@@ -27,8 +27,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_PSP_GetVersionString
- *
  *  Purpose: Implemented per public OSAL API
  *           See description in API and header file for detail
  *
@@ -40,8 +38,6 @@ const char *CFE_PSP_GetVersionString(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_PSP_GetVersionCodeName
- *
  *  Purpose: Implemented per public OSAL API
  *           See description in API and header file for detail
  *
@@ -52,8 +48,6 @@ const char *CFE_PSP_GetVersionCodeName(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_PSP_GetVersionNumber
  *
  *  Purpose: Implemented per public OSAL API
  *           See description in API and header file for detail
@@ -68,8 +62,6 @@ void CFE_PSP_GetVersionNumber(uint8 VersionNumbers[4])
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_PSP_GetBuildNumber
  *
  *  Purpose: Implemented per public OSAL API
  *           See description in API and header file for detail

--- a/unit-test-coverage/modules/timebase_vxworks/inc/cfe_psp_config.h
+++ b/unit-test-coverage/modules/timebase_vxworks/inc/cfe_psp_config.h
@@ -45,7 +45,6 @@ typedef struct
 {
     unsigned long PeriodNumerator;
     unsigned long PeriodDenominator;
-
 } UT_PSP_TimeBase_VxWorks_TestConfig_t;
 
 extern UT_PSP_TimeBase_VxWorks_TestConfig_t UT_PSP_TIMEBASE_VXWORKS_TESTCONFIG;

--- a/unit-test-coverage/modules/timebase_vxworks/src/coveragetest-timebase_vxworks.c
+++ b/unit-test-coverage/modules/timebase_vxworks/src/coveragetest-timebase_vxworks.c
@@ -202,7 +202,6 @@ void Test_Rollover(void)
 }
 
 /******************************************************************************
-**  Function:  CFE_PSP_Get_Timebase()
 **
 **  Purpose:
 **    Provides a common interface to system timebase. This routine

--- a/unit-test-coverage/shared/src/coveragetest-cfe-psp-exceptionstorage.c
+++ b/unit-test-coverage/shared/src/coveragetest-cfe-psp-exceptionstorage.c
@@ -59,6 +59,7 @@ void Test_CFE_PSP_Exception_GetBuffer(void)
     UtAssert_True(Ptr0 != Ptr1, "CFE_PSP_Exception_GetBuffer(0) (%p) != CFE_PSP_Exception_GetBuffer(1) (%p)",
                   (void *)Ptr0, (void *)Ptr1);
 }
+
 void Test_CFE_PSP_Exception_GetNextContextBuffer(void)
 {
     /*

--- a/unit-test-coverage/ut-stubs/inc/PCS_moduleLib.h
+++ b/unit-test-coverage/ut-stubs/inc/PCS_moduleLib.h
@@ -47,7 +47,6 @@ typedef struct PCS_MODULE_INFO
         unsigned long bssAddr;
         unsigned long bssSize;
     } segInfo;
-
 } PCS_MODULE_INFO;
 
 /* ----------------------------------------- */

--- a/unit-test-coverage/ut-stubs/src/vxworks-sysLib-stubs.c
+++ b/unit-test-coverage/ut-stubs/src/vxworks-sysLib-stubs.c
@@ -27,6 +27,7 @@ int PCS_sysClkRateGet(void)
 {
     return UT_DEFAULT_IMPL_RC(PCS_sysClkRateGet, 10000);
 }
+
 char *PCS_sysMemTop(void)
 {
     int32 Status;
@@ -46,14 +47,17 @@ void PCS_PciOutByte(uint32_t address, uint8_t data)
 {
     UT_DEFAULT_IMPL(PCS_PciOutByte);
 }
+
 void PCS_PciOutLong(uint32_t address, uint32_t data)
 {
     UT_DEFAULT_IMPL(PCS_PciOutLong);
 }
+
 void PCS_sysPciWrite32(uint32_t address, uint32_t data)
 {
     UT_DEFAULT_IMPL(PCS_sysPciWrite32);
 }
+
 void PCS_sysPciRead32(uint32_t address, uint32_t *data)
 {
     UT_DEFAULT_IMPL(PCS_sysPciRead32);

--- a/unit-test-coverage/ut-stubs/src/vxworks-taskLib-stubs.c
+++ b/unit-test-coverage/ut-stubs/src/vxworks-taskLib-stubs.c
@@ -40,10 +40,12 @@ const char *PCS_taskName(PCS_TASK_ID task_id)
 
     return retval;
 }
+
 void PCS_taskExit(int code)
 {
     UT_DEFAULT_IMPL(PCS_taskExit);
 }
+
 PCS_TASK_ID PCS_taskIdSelf(void)
 {
     int32 Status;
@@ -56,6 +58,7 @@ PCS_TASK_ID PCS_taskIdSelf(void)
 
     return &PCS_LOCAL_TASK;
 }
+
 PCS_TASK_ID PCS_taskNameToId(const char *name)
 {
     int32 Status;
@@ -68,26 +71,32 @@ PCS_TASK_ID PCS_taskNameToId(const char *name)
 
     return &PCS_LOCAL_TASK;
 }
+
 PCS_STATUS PCS_taskDelay(int ticks)
 {
     return UT_DEFAULT_IMPL(PCS_taskDelay);
 }
+
 PCS_STATUS PCS_taskDelete(PCS_TASK_ID tid)
 {
     return UT_DEFAULT_IMPL(PCS_taskDelete);
 }
+
 PCS_STATUS PCS_taskDeleteForce(PCS_TASK_ID tid)
 {
     return UT_DEFAULT_IMPL(PCS_taskDeleteForce);
 }
+
 PCS_STATUS PCS_taskSuspend(PCS_TASK_ID tid)
 {
     return UT_DEFAULT_IMPL(PCS_taskSuspend);
 }
+
 PCS_STATUS PCS_taskResume(PCS_TASK_ID tid)
 {
     return UT_DEFAULT_IMPL(PCS_taskResume);
 }
+
 PCS_STATUS PCS_taskPrioritySet(PCS_TASK_ID tid, int newPriority)
 {
     return UT_DEFAULT_IMPL(PCS_taskPrioritySet);

--- a/unit-test-coverage/ut-stubs/src/vxworks-vxLib-stubs.c
+++ b/unit-test-coverage/ut-stubs/src/vxworks-vxLib-stubs.c
@@ -32,22 +32,27 @@ void PCS_vxTimeBaseGet(uint32_t *u, uint32_t *l)
     *l = 0;
     UT_DEFAULT_IMPL(PCS_vxTimeBaseGet);
 }
+
 void PCS_vxMsrSet(uint32_t val)
 {
     UT_DEFAULT_IMPL(PCS_vxMsrSet);
 }
+
 uint32_t PCS_vxMsrGet(void)
 {
     return UT_DEFAULT_IMPL(PCS_vxMsrGet);
 }
+
 void PCS_vxFpscrSet(uint32_t val)
 {
     UT_DEFAULT_IMPL(PCS_vxFpscrSet);
 }
+
 uint32_t PCS_vxFpscrGet(void)
 {
     return UT_DEFAULT_IMPL(PCS_vxFpscrGet);
 }
+
 uint32_t PCS_vxDecGet(void)
 {
     return UT_DEFAULT_IMPL(PCS_vxDecGet);

--- a/ut-stubs/ut_psp_stubs.c
+++ b/ut-stubs/ut_psp_stubs.c
@@ -777,8 +777,6 @@ int32 CFE_PSP_Exception_CopyContext(uint32 ContextLogId, void *ContextBuf, uint3
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_PSP_GetVersionString
- *
  *  Purpose: Implemented per public OSAL API
  *           See description in API and header file for detail
  *
@@ -803,8 +801,6 @@ const char *CFE_PSP_GetVersionString(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_PSP_GetVersionCodeName
  *
  *  Purpose: Implemented per public OSAL API
  *           See description in API and header file for detail
@@ -831,8 +827,6 @@ const char *CFE_PSP_GetVersionCodeName(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_PSP_GetVersionNumber
- *
  *  Purpose: Implemented per public OSAL API
  *           See description in API and header file for detail
  *
@@ -844,8 +838,6 @@ void CFE_PSP_GetVersionNumber(uint8 VersionNumbers[4])
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_PSP_GetBuildNumber
  *
  *  Purpose: Implemented per public OSAL API
  *           See description in API and header file for detail


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #367
Removes redundant and inconsistent comments (e.g. `/* end of function */`, `/* end if */`, function name in function header comments).
There were also a few cases of unnecessary empty lines (e.g. on the last line before the closing brace of a function) and also missing empty lines (e.g. between functions) which were corrected. Some of these empty lines trigger the CI format checks.
I've left the commits separated for now to make life easier for whoever reviews this. I can squash them if/when this is ready for merge.

**Testing performed**
None (comment and whitespace changes only).

**Expected behavior changes**
No impact on behavior.
These updates will reduce clutter and inconsistency in the code, improving readability.

**Contributor Info**
@thnkslprpt 