### PR TITLE
Fix #311, Free (close) FileDescriptor resource to avoid leak

### DIFF
--- a/fsw/modules/eeprom_mmap_file/cfe_psp_eeprom_mmap_file.c
+++ b/fsw/modules/eeprom_mmap_file/cfe_psp_eeprom_mmap_file.c
@@ -120,6 +120,8 @@ int32 CFE_PSP_SetupEEPROM(uint32 EEPROMSize, cpuaddr *EEPROMAddress)
     */
     *EEPROMAddress = (cpuaddr)DataBuffer;
 
+    close(FileDescriptor);
+
     return 0;
 }
 


### PR DESCRIPTION
*Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #311 
Added additional `close()` for `FileDescriptor` which was missing before the end of the function.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
`FileDescriptor` freed (closed) before going out of scope, avoiding slight resource leak.

**Contributor Info**
Avi @thnkslprpt