### PR TITLE
Fix #373, Squash constParameter warning in linux cfe_psp_memory.c

### DIFF
--- a/fsw/pc-linux/src/cfe_psp_memory.c
+++ b/fsw/pc-linux/src/cfe_psp_memory.c
@@ -757,13 +757,15 @@ void CFE_PSP_DeleteProcessorReservedMemory(void)
 */
 int32 CFE_PSP_GetKernelTextSegmentInfo(cpuaddr *PtrToKernelSegment, uint32 *SizeOfKernelSegment)
 {
-    /*
-    ** Prevent warnings by referencing parameters
-    */
+    /* Check pointers */
     if (PtrToKernelSegment == NULL || SizeOfKernelSegment == NULL)
     {
         return CFE_PSP_ERROR;
     }
+
+    /* Set to known values */
+    *PtrToKernelSegment  = (cpuaddr)0x0;
+    *SizeOfKernelSegment = 0;
 
     return CFE_PSP_ERROR_NOT_IMPLEMENTED;
 }


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #373 

**Testing performed**
CI

**Expected behavior changes**
Squash CI failure/cppcheck style warning

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC