### PR TITLE
Fix #379, Align mismatched function prototype/implem. parameter names

### DIFF
--- a/fsw/mcp750-vxworks/src/cfe_psp_support.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_support.c
@@ -77,9 +77,9 @@ extern CFE_PSP_MemoryBlock_t MCP750_ReservedMemBlock;
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void CFE_PSP_Restart(uint32 reset_type)
+void CFE_PSP_Restart(uint32 resetType)
 {
-    if (reset_type == CFE_PSP_RST_TYPE_POWERON)
+    if (resetType == CFE_PSP_RST_TYPE_POWERON)
     {
         CFE_PSP_ReservedMemoryMap.BootPtr->bsp_reset_type = CFE_PSP_RST_TYPE_POWERON;
         CFE_PSP_FlushCaches(1, MCP750_ReservedMemBlock.BlockPtr, MCP750_ReservedMemBlock.BlockSize);

--- a/fsw/pc-linux/src/cfe_psp_support.c
+++ b/fsw/pc-linux/src/cfe_psp_support.c
@@ -57,9 +57,9 @@ extern char   CFE_PSP_CpuName[];
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void CFE_PSP_Restart(uint32 reset_type)
+void CFE_PSP_Restart(uint32 resetType)
 {
-    if (reset_type == CFE_PSP_RST_TYPE_POWERON)
+    if (resetType == CFE_PSP_RST_TYPE_POWERON)
     {
         OS_printf("CFE_PSP: Exiting cFE with POWERON Reset status.\n");
 
@@ -75,7 +75,7 @@ void CFE_PSP_Restart(uint32 reset_type)
     /*
      * Record the reset type for the next boot.
      */
-    CFE_PSP_ReservedMemoryMap.BootPtr->NextResetType = reset_type;
+    CFE_PSP_ReservedMemoryMap.BootPtr->NextResetType = resetType;
     CFE_PSP_ReservedMemoryMap.BootPtr->ValidityFlag  = CFE_PSP_BOOTRECORD_VALID;
 
     /*

--- a/fsw/pc-rtems/src/cfe_psp_support.c
+++ b/fsw/pc-rtems/src/cfe_psp_support.c
@@ -71,7 +71,7 @@ extern CFE_PSP_MemoryBlock_t PcRtems_ReservedMemBlock;
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void CFE_PSP_Restart(uint32 reset_type)
+void CFE_PSP_Restart(uint32 resetType)
 {
     CFE_PSP_FlushCaches(1, PcRtems_ReservedMemBlock.BlockPtr, PcRtems_ReservedMemBlock.BlockSize);
     OS_printf("%s is not implemented on this platform ( yet ! )\n", __func__);

--- a/fsw/shared/src/cfe_psp_memutils.c
+++ b/fsw/shared/src/cfe_psp_memutils.c
@@ -51,9 +51,9 @@
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_PSP_MemCpy(void *dst, const void *src, uint32 size)
+int32 CFE_PSP_MemCpy(void *dest, const void *src, uint32 n)
 {
-    memcpy(dst, src, size);
+    memcpy(dest, src, n);
     return CFE_PSP_SUCCESS;
 }
 
@@ -63,8 +63,8 @@ int32 CFE_PSP_MemCpy(void *dst, const void *src, uint32 size)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_PSP_MemSet(void *dst, uint8 value, uint32 size)
+int32 CFE_PSP_MemSet(void *dest, uint8 value, uint32 n)
 {
-    memset(dst, (int)value, (size_t)size);
+    memset(dest, (int)value, (size_t)n);
     return CFE_PSP_SUCCESS;
 }

--- a/unit-test-coverage/mcp750-vxworks/src/coveragetest-cfe-psp-support.c
+++ b/unit-test-coverage/mcp750-vxworks/src/coveragetest-cfe-psp-support.c
@@ -49,7 +49,7 @@ void Test_CFE_PSP_Restart(void)
 {
     /*
      * Test Case For:
-     * void CFE_PSP_Restart(uint32 reset_type)
+     * void CFE_PSP_Restart(uint32 resetType)
      */
 
     UT_Setup_ReservedMem_BootRec();

--- a/ut-stubs/ut_psp_stubs.c
+++ b/ut-stubs/ut_psp_stubs.c
@@ -345,10 +345,10 @@ int32 CFE_PSP_GetVolatileDiskMem(cpuaddr *PtrToVolDisk, uint32 *SizeOfVolDisk)
 **        This function does not return a value.
 **
 ******************************************************************************/
-void CFE_PSP_Restart(uint32 reset_type)
+void CFE_PSP_Restart(uint32 resetType)
 {
     UT_DEFAULT_IMPL(CFE_PSP_Restart);
-    UT_Stub_CopyFromLocal(UT_KEY(CFE_PSP_Restart), (uint8 *)&reset_type, sizeof(reset_type));
+    UT_Stub_CopyFromLocal(UT_KEY(CFE_PSP_Restart), (uint8 *)&resetType, sizeof(resetType));
 }
 
 /*****************************************************************************/
@@ -668,7 +668,7 @@ int32 CFE_PSP_MemValidateRange(cpuaddr Address, size_t Size, uint32 MemoryType)
 **        Returns OS_SUCCESS.
 **
 ******************************************************************************/
-int32 CFE_PSP_MemCpy(void *dst, const void *src, uint32 size)
+int32 CFE_PSP_MemCpy(void *dest, const void *src, uint32 n)
 {
     int32 status;
 
@@ -677,7 +677,7 @@ int32 CFE_PSP_MemCpy(void *dst, const void *src, uint32 size)
     if (status >= 0)
     {
         /* this is not actually a stub; it actually has to _do_ the intended function */
-        memcpy(dst, src, size);
+        memcpy(dest, src, n);
     }
 
     return status;
@@ -698,7 +698,7 @@ int32 CFE_PSP_MemCpy(void *dst, const void *src, uint32 size)
 **        Returns OS_SUCCESS.
 **
 ******************************************************************************/
-int32 CFE_PSP_MemSet(void *dst, uint8 value, uint32 size)
+int32 CFE_PSP_MemSet(void *dest, uint8 value, uint32 n)
 {
     int32 status;
 
@@ -707,7 +707,7 @@ int32 CFE_PSP_MemSet(void *dst, uint8 value, uint32 size)
     if (status >= 0)
     {
         /* this is not actually a stub; it actually has to _do_ the intended function */
-        memset(dst, (int)value, (size_t)size);
+        memset(dest, (int)value, (size_t)n);
     }
 
     return status;


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #379 
  - Similar to https://github.com/nasa/cFE/pull/1551/files from cFE

All flight code function declarations now match the implementations (incl. parameter names).

**Testing performed**
GitHub CI actions all passing successfully.
Local test build - 100% tests passing successfully.

**Expected behavior changes**
No change to behavior.
Code clarity and consistency improved.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS.

**Contributor Info**
Avi Weiss @thnkslprpt