### PR TITLE
Fix #387, Replace hand-written function names with __func__

### DIFF
--- a/fsw/mcp750-vxworks/src/cfe_psp_support.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_support.c
@@ -114,7 +114,7 @@ void CFE_PSP_Restart(uint32 reset_type)
 
 void CFE_PSP_Panic(int32 ErrorCode)
 {
-    printf("CFE_PSP_Panic Called with error code = 0x%08X. Exiting.\n", (unsigned int)ErrorCode);
+    printf("%s called with error code = 0x%08X. Exiting.\n", __func__, (unsigned int)ErrorCode);
     exit(-1); /* Need to improve this */
 }
 

--- a/fsw/pc-linux/src/cfe_psp_exception.c
+++ b/fsw/pc-linux/src/cfe_psp_exception.c
@@ -208,7 +208,7 @@ void CFE_PSP_AttachExceptions(void)
      */
     backtrace(Addr, 1);
 
-    OS_printf("CFE_PSP: CFE_PSP_AttachExceptions Called\n");
+    OS_printf("CFE_PSP: %s called\n", __func__);
 
     /*
      * Block most other signals during handler execution.

--- a/fsw/pc-linux/src/cfe_psp_support.c
+++ b/fsw/pc-linux/src/cfe_psp_support.c
@@ -128,7 +128,7 @@ void CFE_PSP_Restart(uint32 reset_type)
 
 void CFE_PSP_Panic(int32 ErrorCode)
 {
-    OS_printf("CFE_PSP_Panic Called with error code = 0x%08X. Exiting.\n", (unsigned int)ErrorCode);
+    OS_printf("%s called with error code = 0x%08X. Exiting.\n", __func__, (unsigned int)ErrorCode);
     OS_printf("The cFE could not start.\n");
     abort(); /* abort() is preferable to exit(-1), as it may create a core file for debug */
 }
@@ -147,7 +147,7 @@ void CFE_PSP_Panic(int32 ErrorCode)
 */
 void CFE_PSP_FlushCaches(uint32 type, void *address, uint32 size)
 {
-    printf("CFE_PSP_FlushCaches called -- Currently no Linux/OSX/Cygwin implementation\n");
+    printf("%s called -- Currently no Linux/OSX/Cygwin implementation\n", __func__);
 }
 
 /*

--- a/fsw/pc-rtems/src/cfe_psp_exception.c
+++ b/fsw/pc-rtems/src/cfe_psp_exception.c
@@ -65,7 +65,7 @@
 */
 void CFE_PSP_AttachExceptions(void)
 {
-    OS_printf("CFE_PSP: CFE_PSP_AttachExceptions Called\n");
+    OS_printf("CFE_PSP: %s called\n", __func__);
     CFE_PSP_Exception_Reset();
 }
 

--- a/fsw/pc-rtems/src/cfe_psp_support.c
+++ b/fsw/pc-rtems/src/cfe_psp_support.c
@@ -80,7 +80,7 @@ extern CFE_PSP_MemoryBlock_t PcRtems_ReservedMemBlock;
 void CFE_PSP_Restart(uint32 reset_type)
 {
     CFE_PSP_FlushCaches(1, PcRtems_ReservedMemBlock.BlockPtr, PcRtems_ReservedMemBlock.BlockSize);
-    OS_printf("CFE_PSP_Restart is not implemented on this platform ( yet ! )\n");
+    OS_printf("%s is not implemented on this platform ( yet ! )\n", __func__);
     exit(-1);
 }
 
@@ -99,7 +99,7 @@ void CFE_PSP_Restart(uint32 reset_type)
 
 void CFE_PSP_Panic(int32 ErrorCode)
 {
-    printf("CFE_PSP_Panic Called with error code = 0x%08X. Exiting.\n", (unsigned int)ErrorCode);
+    printf("%s called with error code = 0x%08X. Exiting.\n", __func__, (unsigned int)ErrorCode);
     OS_ApplicationExit(ErrorCode);
 }
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #387
  - Updated a few `printf()` strings with hand-written function names to use the `__func__` identifier.

Although the names of these functions are unlikely to change, it never hurts to lower dependence on hand-written comments that may need to be updated in the future. May as well use the functionality provided by the predefined identifiers if it's available.

**Testing performed**
GitHub CI actions all passing successfully and local cFS bundle tests confirm no issues.

**Expected behavior changes**
No change to behavior.

**Contributor Info**
Avi Weiss @thnkslprpt