### PR TITLE
RTEMS.cmake: add quotes around ${RTEMS_BSP_C_FLAGS}.

### DIFF
--- a/cmake/Modules/Platform/RTEMS.cmake
+++ b/cmake/Modules/Platform/RTEMS.cmake
@@ -67,7 +67,7 @@ else()
    # Then run "rtems-syms" and re-link the output into a final executable
    set(CMAKE_C_LINK_EXECUTABLE
        "<CMAKE_C_COMPILER> ${RTEMS_SYS_SPECS_FLAGS} ${RTEMS_BSP_C_FLAGS} <FLAGS> ${RTEMS_SYS_LINKFLAGS} -o <TARGET>-prelink <OBJECTS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <LINK_LIBRARIES>"
-       "${RTEMS_TOOLS_PREFIX}/bin/rtems-syms -v -e -c ${RTEMS_BSP_C_FLAGS} -C <CMAKE_C_COMPILER> -o <TARGET>-dl-sym.o <TARGET>-prelink"
+       "${RTEMS_TOOLS_PREFIX}/bin/rtems-syms -v -e -c \"${RTEMS_BSP_C_FLAGS}\" -C <CMAKE_C_COMPILER> -o <TARGET>-dl-sym.o <TARGET>-prelink"
        "<CMAKE_C_COMPILER> ${RTEMS_SYS_SPECS_FLAGS} ${RTEMS_BSP_C_FLAGS} <FLAGS> ${RTEMS_SYS_LINKFLAGS} -o <TARGET> <TARGET>-dl-sym.o <OBJECTS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <LINK_LIBRARIES>")
 endif(RTEMS_DYNAMIC_LOAD)
 


### PR DESCRIPTION
Without the quotes, only the first argument is actually passed to the compiler by rtems-syms.

**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [X] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
- This change ensures that all flags from `RTEMS_BSP_C_FLAGS` are passed from `rtems-syms` to the compiler.

**Testing performed**
Steps taken to test the contribution:
1. Only tested to check if compilation succeeds.

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: N/A
 - Behavior Change: xxx (if applicable)

Before: The only flag that `rtems-syms` passes to the compiler is `-march=armv7-a`. This causes a crash because the compiler assumes the wrong floating point ABI.
```
/home/jacob/projects/rtems/6/bin/rtems-syms -vvv -e -c -march=armv7-a -mthumb -mfpu=neon -mfloat-abi=hard -mtune=cortex-a7 -fno-common -fdata-sections -ffunction-sections -C /home/jacob/projects/rtems/6/bin/arm-rtems6-gcc -o cmTC_56657.exe-dl-sym.o cmTC_56657.exe-prelink
    RTEMS Kernel Symbols 6.ac1fee4f04fe
    kernel: cmTC_56657.exe-prelink
    cache:load-sym: object files: 1
    cache:load-sym: symbols: 1459
    Filtered symbols: 1074
    symbol C file: /tmp/ccaneeaa.c
    symbol O file: cmTC_56657.exe-dl-sym.o
    execute: /home/jacob/projects/rtems/6/bin/arm-rtems6-gcc -march=armv7-a -O2 -c -o cmTC_56657.exe-dl-sym.o /tmp/ccaneeaa.c 
```

After: All flags are correctly passed to the compiler. The floating point ABI is correctly specified.
```
/home/jacob/projects/rtems/6/bin/rtems-syms -vvv -e -c "-march=armv7-a -mthumb -mfpu=neon -mfloat-abi=hard -mtune=cortex-a7 -fno-common -fdata-sections -ffunction-sections" -C /home/jacob/projects/rtems/6/bin/arm-rtems6-gcc -o cmTC_ed3ae.exe-dl-sym.o cmTC_ed3ae.exe-prelink
RTEMS Kernel Symbols 6.ac1fee4f04fe
kernel: cmTC_ed3ae.exe-prelink
cache:load-sym: object files: 1
cache:load-sym: symbols: 1463
Filtered symbols: 1075
symbol C file: /tmp/ccNoeeaa.c
symbol O file: cmTC_ed3ae.exe-dl-sym.o
execute: /home/jacob/projects/rtems/6/bin/arm-rtems6-gcc -march=armv7-a -mthumb -mfpu=neon -mfloat-abi=hard -mtune=cortex-a7 -fno-common -fdata-sections -ffunction-sections -O2 -c -o cmTC_ed3ae.exe-dl-sym.o /tmp/ccNoeeaa.c 
```

**System(s) tested on**
 - Hardware: Raspberry Pi 3.
 - OS: Building on Ubuntu 22.04 for RTEMS 6.
 - Versions: PSP `draco-rc4`.

**Additional context**
N/A

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Jacob Killelea / Personal