### PR TITLE
Fix #393, find psp standard module

### DIFF
--- a/fsw/shared/src/cfe_psp_module.c
+++ b/fsw/shared/src/cfe_psp_module.c
@@ -52,6 +52,7 @@
 #define CFE_PSP_INTERNAL_MODULE_BASE ((CFE_PSP_MODULE_BASE | CFE_PSP_MODULE_INDEX_MASK) & ~0xFF)
 
 static uint32 CFE_PSP_ConfigPspModuleListLength = 0;
+static uint32 CFE_PSP_StandardPspModuleListLength = 0;
 
 /***************************************************
  *
@@ -96,10 +97,9 @@ uint32_t CFE_PSP_ModuleInitList(uint32 BaseId, CFE_StaticModuleLoadEntry_t *List
 void CFE_PSP_ModuleInit(void)
 {
     /* First initialize the fixed set of modules for this PSP */
-    CFE_PSP_ModuleInitList(CFE_PSP_INTERNAL_MODULE_BASE, CFE_PSP_BASE_MODULE_LIST);
+    CFE_PSP_StandardPspModuleListLength = CFE_PSP_ModuleInitList(CFE_PSP_INTERNAL_MODULE_BASE, CFE_PSP_BASE_MODULE_LIST);
 
     /* Then initialize any user-selected extension modules */
-    /* Only these modules can be used with CFE_PSP_Module_GetAPIEntry or CFE_PSP_Module_FindByName */
     CFE_PSP_ConfigPspModuleListLength = CFE_PSP_ModuleInitList(CFE_PSP_MODULE_BASE, GLOBAL_CONFIGDATA.PspModuleList);
 }
 
@@ -115,11 +115,24 @@ int32 CFE_PSP_Module_GetAPIEntry(uint32 PspModuleId, CFE_PSP_ModuleApi_t **API)
     Result = CFE_PSP_INVALID_MODULE_ID;
     if ((PspModuleId & ~CFE_PSP_MODULE_INDEX_MASK) == CFE_PSP_MODULE_BASE)
     {
-        LocalId = PspModuleId & CFE_PSP_MODULE_INDEX_MASK;
-        if (LocalId < CFE_PSP_ConfigPspModuleListLength)
+        /* Last 256 enteries are for internal modules */
+        if((PspModuleId & CFE_PSP_MODULE_INDEX_MASK) >= 0xFF00 )
         {
-            *API   = (CFE_PSP_ModuleApi_t *)GLOBAL_CONFIGDATA.PspModuleList[LocalId].Api;
-            Result = CFE_PSP_SUCCESS;
+            LocalId = PspModuleId & 0xFF;
+            if (LocalId < CFE_PSP_StandardPspModuleListLength)
+            {
+                *API   = (CFE_PSP_ModuleApi_t *)CFE_PSP_BASE_MODULE_LIST[LocalId].Api;
+                Result = CFE_PSP_SUCCESS;
+            }
+        }
+        else
+        {
+            LocalId = PspModuleId & CFE_PSP_MODULE_INDEX_MASK;
+            if (LocalId < CFE_PSP_ConfigPspModuleListLength)
+            {
+                *API   = (CFE_PSP_ModuleApi_t *)GLOBAL_CONFIGDATA.PspModuleList[LocalId].Api;
+                Result = CFE_PSP_SUCCESS;
+            }
         }
     }
 
@@ -139,6 +152,8 @@ int32 CFE_PSP_Module_FindByName(const char *ModuleName, uint32 *PspModuleId)
     Entry  = GLOBAL_CONFIGDATA.PspModuleList;
     Result = CFE_PSP_INVALID_MODULE_NAME;
     i      = 0;
+
+    /* Check global list */
     while (i < CFE_PSP_ConfigPspModuleListLength)
     {
         if (strcmp(Entry->Name, ModuleName) == 0)
@@ -149,6 +164,24 @@ int32 CFE_PSP_Module_FindByName(const char *ModuleName, uint32 *PspModuleId)
         }
         ++Entry;
         ++i;
+    }
+
+    /* Check internal list */
+    if (Result != CFE_PSP_SUCCESS)
+    {
+        Entry = CFE_PSP_BASE_MODULE_LIST;
+        i     = 0;
+        while (i < CFE_PSP_StandardPspModuleListLength)
+        {
+            if (strcmp(Entry->Name, ModuleName) == 0)
+            {
+                *PspModuleId = CFE_PSP_INTERNAL_MODULE_BASE | (i & CFE_PSP_MODULE_INDEX_MASK);
+                Result       = CFE_PSP_SUCCESS;
+                break;
+            }
+            ++Entry;
+            ++i;
+        }
     }
 
     return Result;


### PR DESCRIPTION
Update to find psp module from standard list as well as global list

**Checklist (Please check before submitting)**

* [x ] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [ x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
Fixes #393. Since Linux Symon is part of the standard module, CFE_PSP_Module_FindByName and CFE_PSP_Module_GetAPIEntry also need to search the standard module list. This fix let these function iterate through CFE_PSP_BASE_MODULE_LIST as well as GLOBAL_CONFIGDATA.PspModuleList.

**Testing performed**
Steps taken to test the contribution:
1. Build with HS and linux sysmon as part of standard psp.
2. See the telemetry

1. Build with HS and Linux sysmon as part of the global psp list (add into target.cmake instead of standard psp)
2. See telemetry 

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: xxx (if applicable)
 - Behavior Change: xxx (if applicable)
 - Or no impact to behavior

**System(s) tested on**
- VM with Ubuntu 20.04

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLAs apply to only software contributions.

Anh Van. GSFC
