### PR TITLE
Fix #413, Add coverage tests for pc-rtems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,5 +71,5 @@ target_include_directories(psp-${CFE_PSP_TARGETNAME} INTERFACE
 if (ENABLE_UNIT_TESTS)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ut-stubs)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/unit-test-coverage)
-endif (ENABLE_UNIT_TESTS)
+endif ()
 

--- a/fsw/pc-rtems/src/cfe_psp_start.c
+++ b/fsw/pc-rtems/src/cfe_psp_start.c
@@ -36,8 +36,6 @@
 #include <rtems/rtems_dhcp_failsafe.h>
 #include <bsp.h>
 
-extern int rtems_fxp_attach(struct rtems_bsdnet_ifconfig *config, int attaching);
-
 /*
 ** cFE includes
 */
@@ -145,7 +143,7 @@ void OS_Application_Startup(void)
 {
     if (CFE_PSP_Setup() != RTEMS_SUCCESSFUL)
     {
-        CFE_PSP_Panic(CFE_PSP_ERROR);
+        CFE_PSP_Panic(CFE_PSP_ERROR); /* Unreachable currently - CFE_PSP_Setup always returns RTEMS_SUCCESSFUL */
     }
 
     /*

--- a/unit-test-coverage/CMakeLists.txt
+++ b/unit-test-coverage/CMakeLists.txt
@@ -13,15 +13,14 @@
 
 project(PSPCOVERAGE C)
 
-# Currently only mcp750-vxworks is implemented a demonstration of how this works.
-set(PSPCOVERAGE_TARGETS "mcp750-vxworks" CACHE STRING "PSP target(s) to build coverage tests for (default=all)")
+set(PSPCOVERAGE_TARGETS mcp750-vxworks pc-rtems CACHE STRING "PSP target(s) to build coverage tests for (default=all)")
 
 # Check that coverage has been implemented for this PSPTYPE
 foreach(PSPTYPE ${PSPCOVERAGE_TARGETS})
     if (NOT IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${PSPTYPE})
       message(FATAL_ERROR "No coverage tests implemented for ${PSPTYPE}")
-    endif (NOT IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${PSPTYPE})
-endforeach(PSPTYPE ${PSPCOVERAGE_TARGETS})
+    endif ()
+endforeach()
 
 message(STATUS "PSP Coverage Test Targets: ${PSPCOVERAGE_TARGETS}")
 
@@ -35,5 +34,5 @@ add_subdirectory(modules)
 # Build targets for each of the indicated PSPs
 foreach(SETNAME ${PSPCOVERAGE_TARGETS})
     add_subdirectory(${SETNAME})
-endforeach(SETNAME ${PSPCOVERAGE_TARGETS})
+endforeach()
 

--- a/unit-test-coverage/mcp750-vxworks/adaptors/CMakeLists.txt
+++ b/unit-test-coverage/mcp750-vxworks/adaptors/CMakeLists.txt
@@ -1,5 +1,5 @@
 # "Adaptors" help enable the unit test code to reach functions/objects that
-# are otherwise not exposed.  
+# are otherwise not exposed.
 
 # NOTE: These source files are compiled with OVERRIDES on the headers just like
 # the FSW code is compiled.  This is how it is able to include internal headers
@@ -21,7 +21,7 @@ target_include_directories(ut-adaptor-${CFE_PSP_TARGETNAME} PUBLIC
     ${PSPCOVERAGE_SOURCE_DIR}/shared/adaptors/inc
 )
 
-target_link_libraries(ut-adaptor-${CFE_PSP_TARGETNAME} PRIVATE 
+target_link_libraries(ut-adaptor-${CFE_PSP_TARGETNAME} PRIVATE
     psp_module_api
-    ut_assert 
+    ut_assert
 )

--- a/unit-test-coverage/modules/CMakeLists.txt
+++ b/unit-test-coverage/modules/CMakeLists.txt
@@ -61,7 +61,7 @@ function(add_psp_covtest MODULE_NAME TESTCASE_SRC UT_SRCS)
         install(TARGETS ${RUNNER_TARGET} DESTINATION ${TGT}/${UT_INSTALL_SUBDIR})
     endforeach()
 
-endfunction(add_psp_covtest)
+endfunction()
 
 
 # a list of modules for which there is a coverage test implemented

--- a/unit-test-coverage/pc-rtems/CMakeLists.txt
+++ b/unit-test-coverage/pc-rtems/CMakeLists.txt
@@ -1,0 +1,50 @@
+######################################################################
+#
+# CMake build recipe for pc-rtems PSP white-box coverage tests
+#
+######################################################################
+
+include_directories(${CFEPSP_SOURCE_DIR}/fsw/pc-rtems/inc)
+include_directories(${PSPCOVERAGE_SOURCE_DIR}/shared/inc)
+
+# Target names use a "ut" prefix to avoid confusion with the FSW targets
+set(CFE_PSP_TARGETNAME "ut-${SETNAME}")
+add_subdirectory(${CFEPSP_SOURCE_DIR}/fsw/${SETNAME} ${CFE_PSP_TARGETNAME}-impl)
+add_subdirectory(${CFEPSP_SOURCE_DIR}/fsw/shared ${CFE_PSP_TARGETNAME}-shared)
+
+# The UT assert library defines OS_Application_Startup, so this redefines ours with a "UT_" prefix
+target_compile_definitions(psp-${CFE_PSP_TARGETNAME}-impl PRIVATE
+    OS_Application_Startup=UT_OS_Application_Startup
+)
+
+foreach(TGT psp-${CFE_PSP_TARGETNAME}-impl psp-${CFE_PSP_TARGETNAME}-shared)
+    target_compile_options(${TGT} PRIVATE ${UT_COVERAGE_COMPILE_FLAGS})
+    target_include_directories(${TGT} BEFORE PRIVATE ${PSPCOVERAGE_SOURCE_DIR}/ut-stubs/override_inc)
+endforeach()
+
+add_executable(coverage-${CFE_PSP_TARGETNAME}-testrunner
+    src/coveragetest-cfe-psp-exception.c
+    src/coveragetest-cfe-psp-memory.c
+    src/coveragetest-cfe-psp-ssr.c
+    src/coveragetest-cfe-psp-start.c
+    src/coveragetest-cfe-psp-support.c
+    src/coveragetest-cfe-psp-watchdog.c
+    src/coveragetest-psp-pc-rtems.c
+    $<TARGET_OBJECTS:psp-${CFE_PSP_TARGETNAME}-shared>
+    $<TARGET_OBJECTS:psp-${CFE_PSP_TARGETNAME}-impl>
+)
+
+target_link_libraries(coverage-${CFE_PSP_TARGETNAME}-testrunner PUBLIC
+    ${UT_COVERAGE_LINK_FLAGS}
+    psp_module_api
+    ut_psp_cfe_stubs
+    ut_psp_libc_stubs
+    ut_osapi_stubs
+    ut_assert
+)
+
+add_test(coverage-${CFE_PSP_TARGETNAME} coverage-${CFE_PSP_TARGETNAME}-testrunner)
+
+foreach(TGT ${INSTALL_TARGET_LIST})
+    install(TARGETS coverage-${CFE_PSP_TARGETNAME}-testrunner DESTINATION ${TGT}/${UT_INSTALL_SUBDIR})
+endforeach()

--- a/unit-test-coverage/pc-rtems/src/coveragetest-cfe-psp-exception.c
+++ b/unit-test-coverage/pc-rtems/src/coveragetest-cfe-psp-exception.c
@@ -1,0 +1,51 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+#include "coveragetest-psp-pc-rtems.h"
+
+#include "cfe_psp.h"
+#include "PCS_stdlib.h"
+
+extern int32 CFE_PSP_ExceptionGetSummary_Impl(void *, char *, uint32);
+extern void  CFE_PSP_SetupReservedMemoryMap(void);
+
+uint32 UT_AttachExceptionsBuffer[1024];
+
+void Test_CFE_PSP_AttachExceptions(void)
+{
+    /* Need to call CFE_PSP_SetupReservedMemoryMap here for initialization of CFE_PSP_ReservedMemoryMap */
+    UT_SetDataBuffer(UT_KEY(PCS_malloc), UT_AttachExceptionsBuffer, sizeof(UT_AttachExceptionsBuffer), false);
+    CFE_PSP_SetupReservedMemoryMap();
+    UT_ResetState(UT_KEY(OS_printf)); /* Reset so calls to OS_printf in the setup above don't affect the actual test */
+
+    /* Nominal path */
+    CFE_PSP_AttachExceptions();
+    UtAssert_STUB_COUNT(OS_printf, 1);
+}
+
+void Test_CFE_PSP_ExceptionGetSummary_Impl(void)
+{
+    /* Placeholder test to exercise function - amend tests if/when function is fully implemented */
+    UtAssert_INT32_EQ(CFE_PSP_ExceptionGetSummary_Impl(NULL, NULL, 4), CFE_PSP_ERROR_NOT_IMPLEMENTED);
+}
+
+void Test_CFE_PSP_SetDefaultExceptionEnvironment(void)
+{
+    /* Placeholder test to exercise function - amend tests if/when function is fully implemented */
+    CFE_PSP_SetDefaultExceptionEnvironment();
+}

--- a/unit-test-coverage/pc-rtems/src/coveragetest-cfe-psp-memory.c
+++ b/unit-test-coverage/pc-rtems/src/coveragetest-cfe-psp-memory.c
@@ -1,0 +1,143 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+#include "coveragetest-psp-pc-rtems.h"
+
+#include "cfe_psp.h"
+#include "PCS_stdlib.h"
+
+extern int32 CFE_PSP_InitProcessorReservedMemory(uint32 ResetType);
+extern void  CFE_PSP_SetupReservedMemoryMap(void);
+
+/* Blocks of 'heap' memory for emulated calls to malloc (via PCS_malloc) in the tests */
+uint32 UT_MemoryMapBuffer[1024];
+uint32 UT_TooSmallMemoryMapBuffer[1];
+
+void Test_CFE_PSP_GetCDSSize(void)
+{
+    uint32 SizeOfCDS;
+
+    /* Test NULL pointer guard */
+    UtAssert_INT32_EQ(CFE_PSP_GetCDSSize(NULL), OS_ERROR);
+
+    /* Nominal/success path */
+    UtAssert_INT32_EQ(CFE_PSP_GetCDSSize(&SizeOfCDS), OS_SUCCESS);
+}
+
+void Test_CFE_PSP_WriteToCDS(void)
+{
+    uint32 CDSOffset = 8;
+    uint32 NumBytes  = 8;
+
+    /* Test NULL pointer guard */
+    UtAssert_INT32_EQ(CFE_PSP_WriteToCDS(NULL, CDSOffset, NumBytes), OS_ERROR);
+}
+
+void Test_CFE_PSP_ReadFromCDS(void)
+{
+    uint32 CDSOffset = 8;
+    uint32 NumBytes  = 8;
+
+    /* Test NULL pointer guard */
+    UtAssert_INT32_EQ(CFE_PSP_ReadFromCDS(NULL, CDSOffset, NumBytes), OS_ERROR);
+}
+
+void Test_CFE_PSP_GetResetArea(void)
+{
+    cpuaddr PtrToResetArea;
+    uint32  SizeOfResetArea;
+
+    /* Test both NULL pointer guards */
+    UtAssert_INT32_EQ(CFE_PSP_GetResetArea(NULL, &SizeOfResetArea), OS_ERROR);
+    UtAssert_INT32_EQ(CFE_PSP_GetResetArea(&PtrToResetArea, NULL), OS_ERROR);
+
+    /* Nominal/success path */
+    UtAssert_INT32_EQ(CFE_PSP_GetResetArea(&PtrToResetArea, &SizeOfResetArea), OS_SUCCESS);
+}
+
+void Test_CFE_PSP_GetUserReservedArea(void)
+{
+    cpuaddr PtrToUserArea;
+    uint32  SizeOfUserArea;
+
+    /* Test both NULL pointer guards */
+    UtAssert_INT32_EQ(CFE_PSP_GetUserReservedArea(NULL, &SizeOfUserArea), OS_ERROR);
+    UtAssert_INT32_EQ(CFE_PSP_GetUserReservedArea(&PtrToUserArea, NULL), OS_ERROR);
+
+    /* Nominal/success path */
+    UtAssert_INT32_EQ(CFE_PSP_GetUserReservedArea(&PtrToUserArea, &SizeOfUserArea), OS_SUCCESS);
+}
+
+void Test_CFE_PSP_GetVolatileDiskMem(void)
+{
+    cpuaddr PtrToVolDisk;
+    uint32  SizeOfVolDisk;
+
+    /* Test both NULL pointer guards */
+    UtAssert_INT32_EQ(CFE_PSP_GetVolatileDiskMem(NULL, &SizeOfVolDisk), OS_ERROR);
+    UtAssert_INT32_EQ(CFE_PSP_GetVolatileDiskMem(&PtrToVolDisk, NULL), OS_ERROR);
+
+    /* Nominal/success path */
+    UtAssert_INT32_EQ(CFE_PSP_GetVolatileDiskMem(&PtrToVolDisk, &SizeOfVolDisk), OS_SUCCESS);
+}
+
+void Test_CFE_PSP_SetupReservedMemoryMap(void)
+{
+    /* Test NULL ReservedMemBlock.BlockPtr path and early abort due to failure of malloc with a too-small heap */
+    UT_SetDataBuffer(UT_KEY(PCS_malloc), UT_TooSmallMemoryMapBuffer, sizeof(UT_TooSmallMemoryMapBuffer), false);
+    CFE_PSP_SetupReservedMemoryMap();
+    UtAssert_STUB_COUNT(PCS_abort, 1);
+    UT_ResetState(UT_KEY(PCS_malloc)); /* Reset so cleared for next test */
+    UT_ResetState(UT_KEY(OS_printf));  /* Reset so cleared for next test */
+
+    /* Nominal/success path with sufficiently sized 'heap' for emulated call to malloc */
+    UT_SetDataBuffer(UT_KEY(PCS_malloc), UT_MemoryMapBuffer, sizeof(UT_MemoryMapBuffer), false);
+    CFE_PSP_SetupReservedMemoryMap();
+    UtAssert_STUB_COUNT(OS_printf, 3); /* 3 calls to OS_printf along nominal path in CFE_PSP_SetupReservedMemoryMap */
+}
+
+void Test_CFE_PSP_InitProcessorReservedMemory(void)
+{
+    /* Always returns CFE_PSP_SUCCESS */
+    UtAssert_INT32_EQ(CFE_PSP_InitProcessorReservedMemory(CFE_PSP_RST_TYPE_POWERON), CFE_PSP_SUCCESS);
+}
+
+void Test_CFE_PSP_GetKernelTextSegmentInfo(void)
+{
+    cpuaddr PtrToKernelSegment;
+    uint32  SizeOfKernelSegment;
+
+    /* Test both NULL pointer guards */
+    UtAssert_INT32_EQ(CFE_PSP_GetKernelTextSegmentInfo(NULL, &SizeOfKernelSegment), OS_ERROR);
+    UtAssert_INT32_EQ(CFE_PSP_GetKernelTextSegmentInfo(&PtrToKernelSegment, NULL), OS_ERROR);
+
+    /* Nominal/success path */
+    UtAssert_INT32_EQ(CFE_PSP_GetKernelTextSegmentInfo(&PtrToKernelSegment, &SizeOfKernelSegment), OS_SUCCESS);
+}
+
+void Test_CFE_PSP_GetCFETextSegmentInfo(void)
+{
+    cpuaddr PtrToCFESegment;
+    uint32  SizeOfCFESegment;
+
+    /* Test NULL pointer guard */
+    UtAssert_INT32_EQ(CFE_PSP_GetCFETextSegmentInfo(&PtrToCFESegment, NULL), OS_ERROR);
+
+    /* Nominal/success path */
+    UtAssert_INT32_EQ(CFE_PSP_GetCFETextSegmentInfo(&PtrToCFESegment, &SizeOfCFESegment), OS_SUCCESS);
+}

--- a/unit-test-coverage/pc-rtems/src/coveragetest-cfe-psp-ssr.c
+++ b/unit-test-coverage/pc-rtems/src/coveragetest-cfe-psp-ssr.c
@@ -16,23 +16,16 @@
  * limitations under the License.
  ************************************************************************/
 
-/* PSP coverage stub replacement for stdlib.h */
-#ifndef OVERRIDE_STDLIB_H
-#define OVERRIDE_STDLIB_H
+#include "coveragetest-psp-pc-rtems.h"
 
-#include "PCS_stdlib.h"
+#include "cfe_psp.h"
 
-/* ----------------------------------------- */
-/* mappings for declarations in stdlib.h */
-/* ----------------------------------------- */
+void Test_CFE_PSP_InitSSR(void)
+{
+    uint32 bus          = 1;
+    uint32 device       = 1;
+    char   DeviceName[] = "TestDevice";
 
-#define EXIT_SUCCESS PCS_EXIT_SUCCESS
-#define EXIT_FAILURE PCS_EXIT_FAILURE
-#define exit         PCS_exit
-#define strtoul      PCS_strtoul
-#define system       PCS_system
-#define malloc       PCS_malloc
-#define free         PCS_free
-#define abort        PCS_abort
-
-#endif
+    /* Placeholder test to exercise function - amend tests if/when function is fully implemented */
+    UtAssert_INT32_EQ(CFE_PSP_InitSSR(bus, device, DeviceName), CFE_PSP_SUCCESS);
+}

--- a/unit-test-coverage/pc-rtems/src/coveragetest-cfe-psp-start.c
+++ b/unit-test-coverage/pc-rtems/src/coveragetest-cfe-psp-start.c
@@ -1,0 +1,85 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+#include "coveragetest-psp-pc-rtems.h"
+
+#include "cfe_psp.h"
+
+#include "PCS_rtems.h"
+#include "PCS_bsdnet.h"
+#include "PCS_stdlib.h"
+#include "PCS_stdio.h"
+
+extern int CFE_PSP_Setup(void);
+
+/* NOTE: The UT assert library itself defines OS_Application_Startup. To avoid conflict with the UT assert,
+ * version, the unit under test is renamed to "UT_OS_Application_Startup" using a preprocessor definition. */
+extern void UT_OS_Application_Startup(void);
+
+/* Blocks of 'heap' memory for emulated calls to malloc (via PCS_malloc) in the tests */
+uint32 UT_StartupBuffer[1024];
+uint32 UT_MainBuffer[1024];
+
+void Test_CFE_PSP_Setup(void)
+{
+    /* Nominal/Success path */
+    UtAssert_INT32_EQ(CFE_PSP_Setup(), PCS_RTEMS_SUCCESSFUL);
+
+    /* Test for printf due to error from rtems_bsdnet_initialize_network (function still returns RTEMS_SUCCESSFUL) */
+    UT_SetDefaultReturnValue(UT_KEY(PCS_rtems_bsdnet_initialize_network), -1);
+    UtAssert_INT32_EQ(CFE_PSP_Setup(), PCS_RTEMS_SUCCESSFUL);
+    UtAssert_STUB_COUNT(PCS_printf, 1);
+}
+
+void Test_OS_Application_Startup(void)
+{
+    /* Set up 'heap' buffer for emulated calls to malloc */
+    UT_SetDataBuffer(UT_KEY(PCS_malloc), UT_StartupBuffer, sizeof(UT_StartupBuffer), false);
+    UT_OS_Application_Startup();
+    UtAssert_STUB_COUNT(OS_API_Init, 1); /* Test for successful initialization (called by CFE_PSP_Main) */
+
+    /* Cannot test for failure of CFE_PSP_Setup (it always returns RTEMS_SUCCESSFUL in the current implementation - so
+     * this branch is unreachable) */
+}
+
+void Test_CFE_PSP_Main(void)
+{
+    /* Set up 'heap' buffer for emulated calls to malloc */
+    UT_SetDataBuffer(UT_KEY(PCS_malloc), UT_MainBuffer, sizeof(UT_MainBuffer), false);
+
+    /* Nominal/Success path */
+    CFE_PSP_Main();
+    UtAssert_STUB_COUNT(OS_API_Init, 1);
+    /* Expect 4 x OS_printf - 3 from CFE_PSP_SetupReservedMemoryMap and 1 from CFE_PSP_InitProcessorReservedMemory */
+    UtAssert_STUB_COUNT(OS_printf, 4);
+    UT_ResetState(UT_KEY(OS_printf)); /* Reset so cleared for next test */
+
+    /* Error return from OS_API_Init */
+    UT_SetDefaultReturnValue(UT_KEY(OS_API_Init), OS_ERROR);
+    CFE_PSP_Main();
+    UtAssert_STUB_COUNT(OS_ApplicationExit, 1);
+    UT_ResetState(UT_KEY(OS_printf)); /* Reset so cleared for next test */
+
+    /* Error return from OS_FileSysAddFixedMap */
+    UT_SetDefaultReturnValue(UT_KEY(OS_FileSysAddFixedMap), -1);
+    CFE_PSP_Main();
+    /* Expect 5 total calls to OS_printf - 3 from CFE_PSP_SetupReservedMemoryMap, 1 from status check due to
+     * failure of OS_FileSysAddFixedMap, and 1 from CFE_PSP_InitProcessorReservedMemory */
+    UtAssert_STUB_COUNT(OS_printf, 5);
+    UT_ResetState(UT_KEY(OS_printf)); /* Reset so cleared for future tests */
+}

--- a/unit-test-coverage/pc-rtems/src/coveragetest-cfe-psp-support.c
+++ b/unit-test-coverage/pc-rtems/src/coveragetest-cfe-psp-support.c
@@ -1,0 +1,63 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+#include "cfe_psp.h"
+
+#include "coveragetest-psp-pc-rtems.h"
+
+#include "PCS_stdlib.h"
+#include "PCS_cfe_configdata.h"
+
+void Test_CFE_PSP_Restart(void)
+{
+    CFE_PSP_Restart(CFE_PSP_RST_TYPE_PROCESSOR);
+    UtAssert_STUB_COUNT(PCS_exit, 1);
+    UT_ResetState(UT_KEY(PCS_exit)); /* Reset so cleared for next test */
+
+    CFE_PSP_Restart(CFE_PSP_RST_TYPE_POWERON);
+    UtAssert_STUB_COUNT(PCS_exit, 1);
+}
+
+void Test_CFE_PSP_Panic(void)
+{
+    CFE_PSP_Panic(0);
+    UtAssert_STUB_COUNT(OS_ApplicationExit, 1);
+}
+
+/* Placeholder coverage test */
+void Test_CFE_PSP_FlushCaches(void)
+{
+    CFE_PSP_FlushCaches(0, NULL, 0);
+    CFE_PSP_FlushCaches(1, NULL, 0);
+}
+
+void Test_CFE_PSP_GetProcessorId(void)
+{
+    UtAssert_INT32_EQ(CFE_PSP_GetProcessorId(), PCS_CONFIG_CPUNUMBER);
+}
+
+void Test_CFE_PSP_GetSpacecraftId(void)
+{
+    UtAssert_INT32_EQ(CFE_PSP_GetSpacecraftId(), PCS_CONFIG_SPACECRAFT);
+}
+
+void Test_CFE_PSP_GetProcessorName(void)
+{
+    UtAssert_STRINGBUF_EQ(CFE_PSP_GetProcessorName(), UTASSERT_STRINGBUF_NULL_TERM, PCS_CONFIG_CPUNAME,
+                          UTASSERT_STRINGBUF_NULL_TERM);
+}

--- a/unit-test-coverage/pc-rtems/src/coveragetest-cfe-psp-watchdog.c
+++ b/unit-test-coverage/pc-rtems/src/coveragetest-cfe-psp-watchdog.c
@@ -16,23 +16,45 @@
  * limitations under the License.
  ************************************************************************/
 
-/* PSP coverage stub replacement for stdlib.h */
-#ifndef OVERRIDE_STDLIB_H
-#define OVERRIDE_STDLIB_H
+#include "coveragetest-psp-pc-rtems.h"
 
-#include "PCS_stdlib.h"
+#include "cfe_psp.h"
 
-/* ----------------------------------------- */
-/* mappings for declarations in stdlib.h */
-/* ----------------------------------------- */
+extern uint32 CFE_PSP_WatchdogValue;
 
-#define EXIT_SUCCESS PCS_EXIT_SUCCESS
-#define EXIT_FAILURE PCS_EXIT_FAILURE
-#define exit         PCS_exit
-#define strtoul      PCS_strtoul
-#define system       PCS_system
-#define malloc       PCS_malloc
-#define free         PCS_free
-#define abort        PCS_abort
+/* Placeholder coverage test */
+void Test_CFE_PSP_WatchdogInit(void)
+{
+    CFE_PSP_WatchdogInit();
+}
 
-#endif
+/* Placeholder coverage test */
+void Test_CFE_PSP_WatchdogEnable(void)
+{
+    CFE_PSP_WatchdogEnable();
+}
+
+/* Placeholder coverage test */
+void Test_CFE_PSP_WatchdogDisable(void)
+{
+    CFE_PSP_WatchdogDisable();
+}
+
+/* Placeholder coverage test */
+void Test_CFE_PSP_WatchdogService(void)
+{
+    CFE_PSP_WatchdogService();
+}
+
+void Test_CFE_PSP_WatchdogGet(void)
+{
+    UtAssert_INT32_EQ(CFE_PSP_WatchdogGet(), CFE_PSP_WatchdogValue);
+}
+
+void Test_CFE_PSP_WatchdogSet(void)
+{
+    uint32 WatchdogValueToSet = 42;
+
+    CFE_PSP_WatchdogSet(WatchdogValueToSet);
+    UtAssert_INT32_EQ(CFE_PSP_WatchdogValue, WatchdogValueToSet);
+}

--- a/unit-test-coverage/pc-rtems/src/coveragetest-psp-pc-rtems.c
+++ b/unit-test-coverage/pc-rtems/src/coveragetest-psp-pc-rtems.c
@@ -1,0 +1,70 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+#include "coveragetest-psp-pc-rtems.h"
+
+void Psp_Test_Setup(void)
+{
+    UT_ResetState(0);
+}
+
+void Psp_Test_Teardown(void) {}
+
+void UtTest_Setup(void)
+{
+    /* Coverage test cases for cfs_psp_exception.c */
+    ADD_TEST(CFE_PSP_AttachExceptions);
+    ADD_TEST(CFE_PSP_ExceptionGetSummary_Impl);
+    ADD_TEST(CFE_PSP_SetDefaultExceptionEnvironment);
+
+    /* Coverage test cases for cfs_psp_memory.c */
+    ADD_TEST(CFE_PSP_GetCDSSize);
+    ADD_TEST(CFE_PSP_WriteToCDS);
+    ADD_TEST(CFE_PSP_ReadFromCDS);
+    ADD_TEST(CFE_PSP_GetResetArea);
+    ADD_TEST(CFE_PSP_GetUserReservedArea);
+    ADD_TEST(CFE_PSP_GetVolatileDiskMem);
+    ADD_TEST(CFE_PSP_SetupReservedMemoryMap);
+    ADD_TEST(CFE_PSP_InitProcessorReservedMemory);
+    ADD_TEST(CFE_PSP_GetKernelTextSegmentInfo);
+    ADD_TEST(CFE_PSP_GetCFETextSegmentInfo);
+
+    /* Coverage test cases for cfs_psp_ssr.c */
+    ADD_TEST(CFE_PSP_InitSSR);
+
+    /* Coverage test cases for cfs_psp_start.c */
+    ADD_TEST(CFE_PSP_Setup);
+    ADD_TEST(OS_Application_Startup);
+    ADD_TEST(CFE_PSP_Main);
+
+    /* Coverage test cases for cfs_psp_support.c */
+    ADD_TEST(CFE_PSP_Restart);
+    ADD_TEST(CFE_PSP_Panic);
+    ADD_TEST(CFE_PSP_FlushCaches);
+    ADD_TEST(CFE_PSP_GetProcessorId);
+    ADD_TEST(CFE_PSP_GetSpacecraftId);
+    ADD_TEST(CFE_PSP_GetProcessorName);
+
+    /* Coverage test cases for cfs_psp_watchdog.c */
+    ADD_TEST(CFE_PSP_WatchdogInit);
+    ADD_TEST(CFE_PSP_WatchdogEnable);
+    ADD_TEST(CFE_PSP_WatchdogDisable);
+    ADD_TEST(CFE_PSP_WatchdogService);
+    ADD_TEST(CFE_PSP_WatchdogGet);
+    ADD_TEST(CFE_PSP_WatchdogSet);
+}

--- a/unit-test-coverage/pc-rtems/src/coveragetest-psp-pc-rtems.h
+++ b/unit-test-coverage/pc-rtems/src/coveragetest-psp-pc-rtems.h
@@ -1,0 +1,74 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+#ifndef COVERAGETEST_PSP_PC_RTEMS_H
+#define COVERAGETEST_PSP_PC_RTEMS_H
+
+#include "utassert.h"
+#include "uttest.h"
+#include "utstubs.h"
+
+#include "coveragetest-psp-shared.h"
+
+#define ADD_TEST(test) UtTest_Add((Test_##test), Psp_Test_Setup, Psp_Test_Teardown, #test)
+
+void Psp_Test_Setup(void);
+void Psp_Test_Teardown(void);
+
+/* Coverage test cases for cfs_psp_exception.c */
+void Test_CFE_PSP_AttachExceptions(void);
+void Test_CFE_PSP_ExceptionGetSummary_Impl(void);
+void Test_CFE_PSP_SetDefaultExceptionEnvironment(void);
+
+/* Coverage test cases for cfs_psp_memory.c */
+void Test_CFE_PSP_GetCDSSize(void);
+void Test_CFE_PSP_WriteToCDS(void);
+void Test_CFE_PSP_ReadFromCDS(void);
+void Test_CFE_PSP_GetResetArea(void);
+void Test_CFE_PSP_GetUserReservedArea(void);
+void Test_CFE_PSP_GetVolatileDiskMem(void);
+void Test_CFE_PSP_SetupReservedMemoryMap(void);
+void Test_CFE_PSP_InitProcessorReservedMemory(void);
+void Test_CFE_PSP_GetKernelTextSegmentInfo(void);
+void Test_CFE_PSP_GetCFETextSegmentInfo(void);
+
+/* Coverage test cases for cfs_psp_ssr.c */
+void Test_CFE_PSP_InitSSR(void);
+
+/* Coverage test cases for cfs_psp_start.c */
+void Test_CFE_PSP_Setup(void);
+void Test_OS_Application_Startup(void);
+void Test_CFE_PSP_Main(void);
+
+/* Coverage test cases for cfs_psp_support.c */
+void Test_CFE_PSP_Restart(void);
+void Test_CFE_PSP_Panic(void);
+void Test_CFE_PSP_FlushCaches(void);
+void Test_CFE_PSP_GetProcessorId(void);
+void Test_CFE_PSP_GetSpacecraftId(void);
+void Test_CFE_PSP_GetProcessorName(void);
+
+/* Coverage test cases for cfs_psp_watchdog.c */
+void Test_CFE_PSP_WatchdogInit(void);
+void Test_CFE_PSP_WatchdogEnable(void);
+void Test_CFE_PSP_WatchdogDisable(void);
+void Test_CFE_PSP_WatchdogService(void);
+void Test_CFE_PSP_WatchdogGet(void);
+void Test_CFE_PSP_WatchdogSet(void);
+
+#endif

--- a/unit-test-coverage/ut-stubs/CMakeLists.txt
+++ b/unit-test-coverage/ut-stubs/CMakeLists.txt
@@ -51,22 +51,23 @@ add_library(ut_psp_libc_stubs STATIC EXCLUDE_FROM_ALL
     src/vxworks-vxLib-stubs.c
     src/vxworks-spyLib-stubs.c
     src/vxworks-spyLibP-stubs.c
+    src/rtems-bsdnet-stubs.c
 )
-    
-target_include_directories(ut_libc_stubs PUBLIC 
+
+target_include_directories(ut_libc_stubs PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/inc
 )
 
-target_link_libraries(ut_psp_libc_stubs PRIVATE 
+target_link_libraries(ut_psp_libc_stubs PRIVATE
     psp_module_api
-    ut_assert 
+    ut_assert
 )
-    
+
 add_library(ut_psp_cfe_stubs STATIC EXCLUDE_FROM_ALL
     src/cfe-configdata-stubs.c
 )
 
-target_link_libraries(ut_psp_cfe_stubs PRIVATE 
+target_link_libraries(ut_psp_cfe_stubs PRIVATE
     psp_module_api
-    ut_assert 
+    ut_assert
 )

--- a/unit-test-coverage/ut-stubs/inc/PCS_bsdnet.h
+++ b/unit-test-coverage/ut-stubs/inc/PCS_bsdnet.h
@@ -16,23 +16,16 @@
  * limitations under the License.
  ************************************************************************/
 
-/* PSP coverage stub replacement for stdlib.h */
-#ifndef OVERRIDE_STDLIB_H
-#define OVERRIDE_STDLIB_H
+/* PSP coverage stub replacement for bsdnet.h */
+#ifndef PCS_BSDNET_H
+#define PCS_BSDNET_H
 
-#include "PCS_stdlib.h"
+#include "PCS_basetypes.h"
+#include "PCS_rtems.h"
 
-/* ----------------------------------------- */
-/* mappings for declarations in stdlib.h */
-/* ----------------------------------------- */
-
-#define EXIT_SUCCESS PCS_EXIT_SUCCESS
-#define EXIT_FAILURE PCS_EXIT_FAILURE
-#define exit         PCS_exit
-#define strtoul      PCS_strtoul
-#define system       PCS_system
-#define malloc       PCS_malloc
-#define free         PCS_free
-#define abort        PCS_abort
+extern int         PCS_rtems_fxp_attach(struct PCS_rtems_bsdnet_ifconfig *, int);
+extern void        PCS_rtems_bsdnet_do_dhcp_failsafe(void);
+extern int         PCS_rtems_bsdnet_initialize_network(void);
+extern const char *PCS_rtems_status_text(PCS_rtems_status_code);
 
 #endif

--- a/unit-test-coverage/ut-stubs/inc/PCS_dhcs_failsafe.h
+++ b/unit-test-coverage/ut-stubs/inc/PCS_dhcs_failsafe.h
@@ -16,23 +16,11 @@
  * limitations under the License.
  ************************************************************************/
 
-/* PSP coverage stub replacement for stdlib.h */
-#ifndef OVERRIDE_STDLIB_H
-#define OVERRIDE_STDLIB_H
+/* PSP coverage stub replacement for rtems_dhcs_failsafe.h */
+#ifndef PCS_DHCP_FAILSAFE_H
+#define PCS_DHCP_FAILSAFE_H
 
-#include "PCS_stdlib.h"
-
-/* ----------------------------------------- */
-/* mappings for declarations in stdlib.h */
-/* ----------------------------------------- */
-
-#define EXIT_SUCCESS PCS_EXIT_SUCCESS
-#define EXIT_FAILURE PCS_EXIT_FAILURE
-#define exit         PCS_exit
-#define strtoul      PCS_strtoul
-#define system       PCS_system
-#define malloc       PCS_malloc
-#define free         PCS_free
-#define abort        PCS_abort
+#include "PCS_basetypes.h"
+#include "PCS_rtems.h"
 
 #endif

--- a/unit-test-coverage/ut-stubs/inc/PCS_rtems.h
+++ b/unit-test-coverage/ut-stubs/inc/PCS_rtems.h
@@ -16,23 +16,34 @@
  * limitations under the License.
  ************************************************************************/
 
-/* PSP coverage stub replacement for stdlib.h */
-#ifndef OVERRIDE_STDLIB_H
-#define OVERRIDE_STDLIB_H
+/* PSP coverage stub replacement for rtems.h */
+#ifndef PCS_RTEMS_H
+#define PCS_RTEMS_H
 
-#include "PCS_stdlib.h"
+#include "PCS_basetypes.h"
 
-/* ----------------------------------------- */
-/* mappings for declarations in stdlib.h */
-/* ----------------------------------------- */
+typedef uint32_t PCS_rtems_task_priority;
+typedef uint32_t PCS_rtems_id;
 
-#define EXIT_SUCCESS PCS_EXIT_SUCCESS
-#define EXIT_FAILURE PCS_EXIT_FAILURE
-#define exit         PCS_exit
-#define strtoul      PCS_strtoul
-#define system       PCS_system
-#define malloc       PCS_malloc
-#define free         PCS_free
-#define abort        PCS_abort
+struct PCS_rtems_bsdnet_ifconfig
+{
+    char *name;
+    int (*attach)(struct PCS_rtems_bsdnet_ifconfig *conf, int attaching);
+    struct PCS_rtems_bsdnet_ifconfig *next;
+    char *                            ip_address;
+    char *                            ip_netmask;
+    void *                            hardware_address;
+};
+
+struct PCS_rtems_bsdnet_config
+{
+    struct PCS_rtems_bsdnet_ifconfig *ifconfig;
+    void (*bootp)(void);
+};
+
+typedef enum
+{
+    PCS_RTEMS_SUCCESSFUL = 0,
+} PCS_rtems_status_code;
 
 #endif

--- a/unit-test-coverage/ut-stubs/inc/PCS_stdlib.h
+++ b/unit-test-coverage/ut-stubs/inc/PCS_stdlib.h
@@ -42,5 +42,6 @@ extern unsigned long int PCS_strtoul(const char *nptr, char **endptr, int base);
 extern int               PCS_system(const char *command);
 extern void *            PCS_malloc(size_t sz);
 extern void              PCS_free(void *ptr);
+extern void              PCS_abort(void);
 
 #endif

--- a/unit-test-coverage/ut-stubs/inc/README.md
+++ b/unit-test-coverage/ut-stubs/inc/README.md
@@ -2,8 +2,8 @@ ABOUT THE SYSTEM HEADER OVERRIDES
 =================================
 
 The "overrides" directory contains replacement versions of many system-provided 
-header files.  All replacement functions and types are identified using an 
-`OCS_` prefix.
+header files.  All replacement functions and types are identified using a 
+`PCS_` prefix.
 
 The header file that a particular source will use depends on the 
 way that the compiler include path is set up.  This is intentional.
@@ -12,16 +12,16 @@ way that the compiler include path is set up.  This is intentional.
 
 This refers to all code _other_ than the unit actually being tested, including
 stub function implementations and test configuration.
- 
+
 All coverage test recipes should include `ut-stubs/inc` in the INCLUDE_DIRECTORIES.
 These prototypes can be explicitly obtained by putting an `overrides/` prefix
 on the #include statement, for instance:
-    
+
     #include <stdio.h>              <-- Gets the regular system version as usual
-    #include <overrides/stdio.h>    <-- Gets this replacement OCS version
-    
+    #include <overrides/stdio.h>    <-- Gets this replacement PCS version
+
 Note that the two shouldn't conflict, so it is possible to include both where needed.
-  
+
 2. For code units under test:
 
 When compiling the actual unit under test with coverage instrumentation,
@@ -29,18 +29,18 @@ the CMake recipe should add "ut-stubs/inc/overrides" into the INCLUDE_DIRECTORIE
 This way, all source files compiled will find these replacements instead of
 the regular system header file.  So a statement like:
 
-    #include <stdio.h>              <-- Gets this replacement OCS version
-    
+    #include <stdio.h>              <-- Gets this replacement PCS version
+
 This way it is possible to simply recompile the original source files and all the
 included system headers will be transparently replaced with these override versions.
 
 When using the file in this way, one must also provide a companion macro to
-divert the actual usage to the OCS namespace as well.  For instance:
+divert the actual usage to the PCS namespace as well.  For instance:
 
-    #define fputs   OCS_fputs
-    
-Will cause all references to `fputs` in the subsequent code to refer to `OCS_fputs`
-instead.  
+    #define fputs   PCS_fputs
+
+Will cause all references to `fputs` in the subsequent code to refer to `PCS_fputs`
+instead.
 
 Important Notes
 ---------------
@@ -55,9 +55,8 @@ header to be used.  These cases are:
     stddef.h  : Macros like offsetof() and size_t/ptrdiff_t must be correct for the CPU
     stdbool.h : Preserves correct boolean semantics
 
- 
+
 Note that header files from all supported platforms (VxWorks, Rtems, Posix) may
 all be placed here.  Since the files are empty placeholders, they simply need to
 exist, and there is no need to duplicate this entire tree for every OS since they
 will overlap considerably.
-  

--- a/unit-test-coverage/ut-stubs/override_inc/bsp.h
+++ b/unit-test-coverage/ut-stubs/override_inc/bsp.h
@@ -16,23 +16,8 @@
  * limitations under the License.
  ************************************************************************/
 
-/* PSP coverage stub replacement for stdlib.h */
-#ifndef OVERRIDE_STDLIB_H
-#define OVERRIDE_STDLIB_H
-
-#include "PCS_stdlib.h"
-
-/* ----------------------------------------- */
-/* mappings for declarations in stdlib.h */
-/* ----------------------------------------- */
-
-#define EXIT_SUCCESS PCS_EXIT_SUCCESS
-#define EXIT_FAILURE PCS_EXIT_FAILURE
-#define exit         PCS_exit
-#define strtoul      PCS_strtoul
-#define system       PCS_system
-#define malloc       PCS_malloc
-#define free         PCS_free
-#define abort        PCS_abort
+/* PSP coverage stub replacement for bsp.h */
+#ifndef OVERRIDE_BSP_H
+#define OVERRIDE_BSP_H
 
 #endif

--- a/unit-test-coverage/ut-stubs/override_inc/rtems.h
+++ b/unit-test-coverage/ut-stubs/override_inc/rtems.h
@@ -16,23 +16,19 @@
  * limitations under the License.
  ************************************************************************/
 
-/* PSP coverage stub replacement for stdlib.h */
-#ifndef OVERRIDE_STDLIB_H
-#define OVERRIDE_STDLIB_H
+/* PSP coverage stub replacement for rtems.h */
+#ifndef OVERRIDE_RTEMS_H
+#define OVERRIDE_RTEMS_H
 
-#include "PCS_stdlib.h"
+#include "PCS_rtems.h"
 
-/* ----------------------------------------- */
-/* mappings for declarations in stdlib.h */
-/* ----------------------------------------- */
+#define rtems_task_priority PCS_rtems_task_priority
+#define rtems_id            PCS_rtems_id
 
-#define EXIT_SUCCESS PCS_EXIT_SUCCESS
-#define EXIT_FAILURE PCS_EXIT_FAILURE
-#define exit         PCS_exit
-#define strtoul      PCS_strtoul
-#define system       PCS_system
-#define malloc       PCS_malloc
-#define free         PCS_free
-#define abort        PCS_abort
+#define rtems_status_code PCS_rtems_status_code
+#define RTEMS_SUCCESSFUL  PCS_RTEMS_SUCCESSFUL
+
+#define rtems_bsdnet_ifconfig PCS_rtems_bsdnet_ifconfig
+#define rtems_bsdnet_config   PCS_rtems_bsdnet_config
 
 #endif

--- a/unit-test-coverage/ut-stubs/override_inc/rtems/rtems_bsdnet.h
+++ b/unit-test-coverage/ut-stubs/override_inc/rtems/rtems_bsdnet.h
@@ -16,23 +16,15 @@
  * limitations under the License.
  ************************************************************************/
 
-/* PSP coverage stub replacement for stdlib.h */
-#ifndef OVERRIDE_STDLIB_H
-#define OVERRIDE_STDLIB_H
+/* PSP coverage stub replacement for rtems_bsdnet.h */
+#ifndef OVERRIDE_BSDNET_H
+#define OVERRIDE_BSDNET_H
 
-#include "PCS_stdlib.h"
+#include "PCS_bsdnet.h"
 
-/* ----------------------------------------- */
-/* mappings for declarations in stdlib.h */
-/* ----------------------------------------- */
-
-#define EXIT_SUCCESS PCS_EXIT_SUCCESS
-#define EXIT_FAILURE PCS_EXIT_FAILURE
-#define exit         PCS_exit
-#define strtoul      PCS_strtoul
-#define system       PCS_system
-#define malloc       PCS_malloc
-#define free         PCS_free
-#define abort        PCS_abort
+#define rtems_status_text               PCS_rtems_status_text
+#define rtems_bsdnet_do_dhcp_failsafe   PCS_rtems_bsdnet_do_dhcp_failsafe
+#define rtems_bsdnet_initialize_network PCS_rtems_bsdnet_initialize_network
+#define rtems_fxp_attach                PCS_rtems_fxp_attach
 
 #endif

--- a/unit-test-coverage/ut-stubs/override_inc/rtems/rtems_dhcp_failsafe.h
+++ b/unit-test-coverage/ut-stubs/override_inc/rtems/rtems_dhcp_failsafe.h
@@ -16,23 +16,8 @@
  * limitations under the License.
  ************************************************************************/
 
-/* PSP coverage stub replacement for stdlib.h */
-#ifndef OVERRIDE_STDLIB_H
-#define OVERRIDE_STDLIB_H
-
-#include "PCS_stdlib.h"
-
-/* ----------------------------------------- */
-/* mappings for declarations in stdlib.h */
-/* ----------------------------------------- */
-
-#define EXIT_SUCCESS PCS_EXIT_SUCCESS
-#define EXIT_FAILURE PCS_EXIT_FAILURE
-#define exit         PCS_exit
-#define strtoul      PCS_strtoul
-#define system       PCS_system
-#define malloc       PCS_malloc
-#define free         PCS_free
-#define abort        PCS_abort
+/* PSP coverage stub replacement for rtems_dhcp_failsafe.h */
+#ifndef OVERRIDE_DCHP_FAILSAFE_H
+#define OVERRIDE_DCHP_FAILSAFE_H
 
 #endif

--- a/unit-test-coverage/ut-stubs/src/libc-stdlib-stubs.c
+++ b/unit-test-coverage/ut-stubs/src/libc-stdlib-stubs.c
@@ -57,6 +57,11 @@ void PCS_exit(int c)
      */
 }
 
+void PCS_abort(void)
+{
+    UT_DEFAULT_IMPL(PCS_abort);
+}
+
 unsigned long int PCS_strtoul(const char *nptr, char **endptr, int base)
 {
     int32         Status;

--- a/unit-test-coverage/ut-stubs/src/rtems-bsdnet-stubs.c
+++ b/unit-test-coverage/ut-stubs/src/rtems-bsdnet-stubs.c
@@ -16,23 +16,38 @@
  * limitations under the License.
  ************************************************************************/
 
-/* PSP coverage stub replacement for stdlib.h */
-#ifndef OVERRIDE_STDLIB_H
-#define OVERRIDE_STDLIB_H
+/* PSP coverage stub replacement for rtems_bsdnet.h */
+#include <stdlib.h>
+#include "utstubs.h"
 
-#include "PCS_stdlib.h"
+#include "PCS_bsdnet.h"
+#include "PCS_rtems.h"
 
-/* ----------------------------------------- */
-/* mappings for declarations in stdlib.h */
-/* ----------------------------------------- */
+void PCS_rtems_bsdnet_do_dhcp_failsafe(void)
+{
+    UT_DEFAULT_IMPL(PCS_rtems_bsdnet_do_dhcp_failsafe);
+}
 
-#define EXIT_SUCCESS PCS_EXIT_SUCCESS
-#define EXIT_FAILURE PCS_EXIT_FAILURE
-#define exit         PCS_exit
-#define strtoul      PCS_strtoul
-#define system       PCS_system
-#define malloc       PCS_malloc
-#define free         PCS_free
-#define abort        PCS_abort
+const char *PCS_rtems_status_text(PCS_rtems_status_code code)
+{
+    const char *ReturnCode = NULL;
+    int32       Status;
 
-#endif
+    Status = UT_DEFAULT_IMPL(PCS_rtems_status_text);
+    if (Status == 0)
+    {
+        UT_Stub_CopyToLocal(UT_KEY(PCS_rtems_status_text), &ReturnCode, sizeof(ReturnCode));
+    }
+
+    return ReturnCode;
+}
+
+int PCS_rtems_bsdnet_initialize_network(void)
+{
+    return UT_DEFAULT_IMPL(PCS_rtems_bsdnet_initialize_network);
+}
+
+int PCS_rtems_fxp_attach(struct PCS_rtems_bsdnet_ifconfig *config, int attaching)
+{
+    return UT_DEFAULT_IMPL(PCS_rtems_fxp_attach);
+}

--- a/ut-stubs/ut_psp_stubs.c
+++ b/ut-stubs/ut_psp_stubs.c
@@ -203,13 +203,7 @@ void CFE_PSP_GetTime(OS_time_t *LocalTime)
 **
 ** \par Description
 **        This function is used to mimic the response of the PSP function
-**        CFE_PSP_WriteToCDS.  The user can adjust the response by setting
-**        the values in the BSPWriteCDSRtn structure prior to this function
-**        being called.  If the value BSPWriteCDSRtn.count is greater than
-**        zero then the counter is decremented; if it then equals zero the
-**        return value is set to the user-defined value BSPWriteCDSRtn.value.
-**        Otherwise, the value of the user-defined variable UT_BSP_Fail
-**        determines the status returned by the function.
+**        CFE_PSP_WriteToCDS.
 **
 ** \par Assumptions, External Events, and Notes:
 **        None
@@ -245,13 +239,7 @@ int32 CFE_PSP_WriteToCDS(const void *PtrToDataToWrite, uint32 CDSOffset, uint32 
 **
 ** \par Description
 **        This function is used to mimic the response of the PSP function
-**        CFE_PSP_ReadFromCDS.  The user can adjust the response by setting
-**        the values in the BSPReadCDSRtn structure prior to this function
-**        being called.  If the value BSPReadCDSRtn.count is greater than
-**        zero then the counter is decremented; if it then equals zero the
-**        return value is set to the user-defined value BSPReadCDSRtn.value.
-**        Otherwise, the value of the user-defined variable UT_BSP_Fail
-**        determines the status returned by the function.
+**        CFE_PSP_ReadFromCDS.
 **
 ** \par Assumptions, External Events, and Notes:
 **        None
@@ -287,8 +275,7 @@ int32 CFE_PSP_ReadFromCDS(void *PtrToDataToRead, uint32 CDSOffset, uint32 NumByt
 **
 ** \par Description
 **        This function is used to mimic the response of the PSP function
-**        CFE_PSP_GetCDSSize.  The user can adjust the response by
-**        setting the value of UT_BSP_Fail prior to this function being called.
+**        CFE_PSP_GetCDSSize.
 **
 ** \par Assumptions, External Events, and Notes:
 **        None
@@ -319,8 +306,7 @@ int32 CFE_PSP_GetCDSSize(uint32 *SizeOfCDS)
 **
 ** \par Description
 **        This function is used to mimic the response of the PSP function
-**        CFE_PSP_GetVolatileDiskMem.  The user can adjust the response by
-**        setting the value of UT_BSP_Fail prior to this function being called.
+**        CFE_PSP_GetVolatileDiskMem.
 **
 ** \par Assumptions, External Events, and Notes:
 **        None


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #413
  - Adds coverage tests for pc-rtems implementation (some function are just placeholders anyway, but the coverage tests are there for users to amend for their implementation).
  - Minor clean-up of CMakeLists.txt files etc.

**Testing performed**
GitHub CI actions all passing successfully and local testing results in the following added coverage for pc-rtems:
![Screenshot 2023-10-16 15 55 22](https://github.com/nasa/PSP/assets/9024662/cc8fc718-4858-4529-b785-7ff9d3d48b2f)

**Expected behavior changes**
No code changes - only adding new tests.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt