### PR TITLE
Fix #416, Removes static on module function declaration macro

### DIFF
--- a/fsw/shared/inc/cfe_psp_module.h
+++ b/fsw/shared/inc/cfe_psp_module.h
@@ -63,7 +63,7 @@ typedef const struct
  * The "name" argument should match the name of the module object file
  */
 #define CFE_PSP_MODULE_DECLARE_SIMPLE(name)              \
-    static void         name##_Init(uint32 PspModuleId); \
+    void                name##_Init(uint32 PspModuleId); \
     CFE_PSP_ModuleApi_t CFE_PSP_##name##_API = {         \
         .ModuleType     = CFE_PSP_MODULE_TYPE_SIMPLE,    \
         .OperationFlags = 0,                             \


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [ x I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #416 

**Testing performed**
Ran w/ overriding a module, worked.

**Expected behavior changes**
Can override modules

**System(s) tested on**
Ubuntu 22 docker, custom project code

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC