### PR TITLE
Fix #418, malloc stub memalign calculation

### DIFF
--- a/unit-test-coverage/ut-stubs/src/libc-stdlib-stubs.c
+++ b/unit-test-coverage/ut-stubs/src/libc-stdlib-stubs.c
@@ -143,7 +143,7 @@ void *PCS_malloc(size_t sz)
         return NULL;
     }
 
-    NextSize  = (NextSize + MPOOL_ALIGN - 1) & ~((size_t)MPOOL_ALIGN);
+    NextSize  = (NextSize + MPOOL_ALIGN - 1) & ~((size_t)MPOOL_ALIGN - 1);
     NextBlock = Rec->BlockAddr + MPOOL_ALIGN;
     Rec->BlockAddr += NextSize;
     Rec->Size += NextSize;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Correct the round-up memory alignment calculation in the stub "malloc" routine.

Fixes #418 

**Testing performed**
Run all unit tests

**Expected behavior changes**
malloc stub now rounds up properly

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Same change as was submitted in nasa/osal#1413

It is likely this was never really used by tests, as this bug had been in there a long time and not noticed.  At least with this it should work as intended if multiple blocks are allocated.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
