### PR TITLE
Fix #412, updating PSP to use new versioning system.

### DIFF
--- a/fsw/mcp750-vxworks/inc/psp_version.h
+++ b/fsw/mcp750-vxworks/inc/psp_version.h
@@ -28,14 +28,21 @@
  * Development Build Macro Definitions
  */
 #define CFE_PSP_IMPL_BUILD_NUMBER   102
-#define CFE_PSP_IMPL_BUILD_BASELINE "v1.6.0-rc4"
+#define CFE_PSP_IMPL_BUILD_BASELINE "equuleus-rc1"
+#define CFE_PSP_BUILD_DEV_CYCLE     "equuleus-rc2" /**< @brief Development: Release name for current development cycle */
+#define CFE_PSP_BUILD_CODENAME      "Equuleus" /**< @brief: Development: Code name for the current build */
 
 /*
  * Version Macros, see \ref cfsversions for definitions.
  */
 #define CFE_PSP_IMPL_MAJOR_VERSION 1  /*!< @brief Major version number */
 #define CFE_PSP_IMPL_MINOR_VERSION 4  /*!< @brief Minor version number */
-#define CFE_PSP_IMPL_REVISION      99 /*!< @brief Revision version number. Value of 99 indicates a development version.*/
+#define CFE_PSP_IMPL_REVISION      0  /*!< @brief Revision version number. Value of 0 indicates a development version.*/
+
+/**
+ * @brief Last official release.
+ */
+#define CFE_PSP_LAST_OFFICIAL "v1.4.0"
 
 /*!
  * @brief Mission revision.
@@ -45,8 +52,6 @@
  * cFS open-source development use (pending resolution of nasa/cFS#440)
  */
 #define CFE_PSP_IMPL_MISSION_REV 0xFF
-
-#define CFE_PSP_IMPL_CODENAME "Draco"
 
 /*
  * Tools to construct version string
@@ -61,12 +66,12 @@
  */
 #define CFE_PSP_IMPL_VERSION CFE_PSP_IMPL_BUILD_BASELINE "+dev" CFE_PSP_IMPL_STR(CFE_PSP_IMPL_BUILD_NUMBER)
 
-/*! @brief DEVELOPMENT Build Version String.
- *  @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
- * official version. @n See @ref cfsversions for format differences between development and release versions.
+/**
+ * @brief Max Version String length.
+ * 
+ * Maximum length that a tblCRCTool version string can be.
+ * 
  */
-#define CFE_PSP_IMPL_VERSION_STRING                \
-    " PSP DEVELOPMENT BUILD " CFE_PSP_IMPL_VERSION \
-    ", Last Official Release: psp v1.4.0" /* For full support please use this version */
+#define CFE_PSP_CFG_MAX_VERSION_STR_LEN 256
 
 #endif

--- a/fsw/pc-linux/inc/psp_version.h
+++ b/fsw/pc-linux/inc/psp_version.h
@@ -28,14 +28,21 @@
  * Development Build Macro Definitions
  */
 #define CFE_PSP_IMPL_BUILD_NUMBER   102
-#define CFE_PSP_IMPL_BUILD_BASELINE "v1.6.0-rc4"
+#define CFE_PSP_IMPL_BUILD_BASELINE "equuleus-rc1"
+#define CFE_PSP_BUILD_DEV_CYCLE     "equuleus-rc2" /**< @brief Development: Release name for current development cycle */
+#define CFE_PSP_BUILD_CODENAME      "Equuleus" /**< @brief: Development: Code name for the current build */
 
 /*
  * Version Macros, see \ref cfsversions for definitions.
  */
 #define CFE_PSP_IMPL_MAJOR_VERSION 1  /*!< @brief Major version number */
 #define CFE_PSP_IMPL_MINOR_VERSION 4  /*!< @brief Minor version number */
-#define CFE_PSP_IMPL_REVISION      99 /*!< @brief Revision version number. Value of 99 indicates a development version.*/
+#define CFE_PSP_IMPL_REVISION      0  /*!< @brief Revision version number. Value of 0 indicates a development version.*/
+
+/**
+ * @brief Last official release.
+ */
+#define CFE_PSP_LAST_OFFICIAL "v1.4.0"
 
 /*!
  * @brief Mission revision.
@@ -45,8 +52,6 @@
  * cFS open-source development use (pending resolution of nasa/cFS#440)
  */
 #define CFE_PSP_IMPL_MISSION_REV 0xFF
-
-#define CFE_PSP_IMPL_CODENAME "Draco"
 
 /*
  * Tools to construct version string
@@ -61,12 +66,12 @@
  */
 #define CFE_PSP_IMPL_VERSION CFE_PSP_IMPL_BUILD_BASELINE "+dev" CFE_PSP_IMPL_STR(CFE_PSP_IMPL_BUILD_NUMBER)
 
-/*! @brief DEVELOPMENT Build Version String.
- *  @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
- * official version. @n See @ref cfsversions for format differences between development and release versions.
+/**
+ * @brief Max Version String length.
+ * 
+ * Maximum length that a tblCRCTool version string can be.
+ * 
  */
-#define CFE_PSP_IMPL_VERSION_STRING                \
-    " PSP DEVELOPMENT BUILD " CFE_PSP_IMPL_VERSION \
-    ", Last Official Release: psp v1.4.0" /* For full support please use this version */
+#define CFE_PSP_CFG_MAX_VERSION_STR_LEN 256
 
 #endif

--- a/fsw/pc-rtems/inc/psp_version.h
+++ b/fsw/pc-rtems/inc/psp_version.h
@@ -28,14 +28,21 @@
  * Development Build Macro Definitions
  */
 #define CFE_PSP_IMPL_BUILD_NUMBER   102
-#define CFE_PSP_IMPL_BUILD_BASELINE "v1.6.0-rc4"
+#define CFE_PSP_IMPL_BUILD_BASELINE "equuleus-rc1"
+#define CFE_PSP_BUILD_DEV_CYCLE     "equuleus-rc2" /**< @brief Development: Release name for current development cycle */
+#define CFE_PSP_BUILD_CODENAME      "Equuleus" /**< @brief: Development: Code name for the current build */
 
 /*
  * Version Macros, see \ref cfsversions for definitions.
  */
 #define CFE_PSP_IMPL_MAJOR_VERSION 1  /*!< @brief Major version number */
 #define CFE_PSP_IMPL_MINOR_VERSION 4  /*!< @brief Minor version number */
-#define CFE_PSP_IMPL_REVISION      99 /*!< @brief Revision version number. Value of 99 indicates a development version.*/
+#define CFE_PSP_IMPL_REVISION      0  /*!< @brief Revision version number. Value of 0 indicates a development version.*/
+
+/**
+ * @brief Last official release.
+ */
+#define CFE_PSP_LAST_OFFICIAL "v1.4.0"
 
 /*!
  * @brief Mission revision.
@@ -45,8 +52,6 @@
  * cFS open-source development use (pending resolution of nasa/cFS#440)
  */
 #define CFE_PSP_IMPL_MISSION_REV 0xFF
-
-#define CFE_PSP_IMPL_CODENAME "Draco"
 
 /*
  * Tools to construct version string
@@ -61,12 +66,12 @@
  */
 #define CFE_PSP_IMPL_VERSION CFE_PSP_IMPL_BUILD_BASELINE "+dev" CFE_PSP_IMPL_STR(CFE_PSP_IMPL_BUILD_NUMBER)
 
-/*! @brief DEVELOPMENT Build Version String.
- *  @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
- * official version. @n See @ref cfsversions for format differences between development and release versions.
+/**
+ * @brief Max Version String length.
+ * 
+ * Maximum length that a tblCRCTool version string can be.
+ * 
  */
-#define CFE_PSP_IMPL_VERSION_STRING                \
-    " PSP DEVELOPMENT BUILD " CFE_PSP_IMPL_VERSION \
-    ", Last Official Release: psp v1.4.0" /* For full support please use this version */
+#define CFE_PSP_CFG_MAX_VERSION_STR_LEN 256
 
 #endif

--- a/fsw/shared/src/cfe_psp_version.c
+++ b/fsw/shared/src/cfe_psp_version.c
@@ -44,7 +44,7 @@ const char *CFE_PSP_GetVersionString(void)
  *-----------------------------------------------------------------*/
 const char *CFE_PSP_GetVersionCodeName(void)
 {
-    return CFE_PSP_IMPL_CODENAME;
+    return CFE_PSP_BUILD_CODENAME;
 }
 
 /*----------------------------------------------------------------


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.
**Checklist (Please check before submitting)**

**Describe the contribution**
Fixes #412.

**Testing performed**
Workflows were run.

**Expected behavior changes**
No behavior changes, however the following changes were made to the versioning system:
1. Build Baseline is set to "equuleus-rc1"
2. Mission Revision is set to to 00
3. "CFE_PSP_BUILD_DEV_CYCLE" macro has been defined
4. Version String has been removed, and all references to it replaced with the Build Baseline/Codename

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Dylan Z. Baker/NASA GSFC