### PR TITLE
Fix #426, conditional module inclusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ target_include_directories(psp_module_api INTERFACE
 
 # Translate the CFE_PSP_TARGETNAME to a set of additional modules to build
 file(STRINGS "${CMAKE_CURRENT_LIST_DIR}/fsw/${CFE_PSP_TARGETNAME}/psp_module_list.cmake" PSP_TARGET_MODULE_LIST REGEX "^[a-zA-Z]")
+include("${CMAKE_CURRENT_LIST_DIR}/fsw/${CFE_PSP_TARGETNAME}/psp_conditional_modules.cmake" OPTIONAL)
 
 # The PSP is currently built in modular parts, consisting of a platform-specific
 # module(s) combined with a shared component which is built for multiple targets.
@@ -72,4 +73,3 @@ if (ENABLE_UNIT_TESTS)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ut-stubs)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/unit-test-coverage)
 endif ()
-

--- a/fsw/pc-rtems/psp_conditional_modules.cmake
+++ b/fsw/pc-rtems/psp_conditional_modules.cmake
@@ -1,0 +1,8 @@
+# The sysmon module only works in RTEMS >= 5.
+# Ideally this check should be VERSION_GREATER_EQUAL 5, but that conditional does
+# not exist in all versions of cmake.
+if(CMAKE_SYSTEM_VERSION VERSION_GREATER 4.99)
+
+    list(APPEND PSP_TARGET_MODULE_LIST rtems_sysmon)
+
+endif()

--- a/fsw/pc-rtems/psp_module_list.cmake
+++ b/fsw/pc-rtems/psp_module_list.cmake
@@ -1,5 +1,9 @@
 # This is a list of modules that is included as a fixed/base set
-# when this PSP is selected.  They must exist under fsw/modules
+# when this PSP is selected.  They must exist under fsw/modules.
+
+# NOTE: This set is REQUIRED for all versions of the platform.
+# If a module only works on some versions of the platform, add
+# if to psp_conditional_modules.cmake instead
 
 soft_timebase
 timebase_posix_clock
@@ -7,4 +11,3 @@ eeprom_notimpl
 ram_direct
 port_notimpl
 iodriver
-rtems_sysmon


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Add a cmake file that extends the PSP_TARGET_MODULE_LIST conditionally. Initially, this can check for a minimum target system version and only include modules that are known to work on that version.  This can be used to make the RTEMS 4.11 build work again.

Fixes #426

**Testing performed**
Build on RTEMS 4.11 and RTEMS 5

**Expected behavior changes**
RTEMS 5 build is not changed - still includes rtems_sysmon module
RTEMS 4.11 build succeeds - but does NOT include rtems_sysmon module

**System(s) tested on**
Debian with RTEMS 4.11 and RTEMS 5 toolchains

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
