### PR TITLE
Fix #429, Adds node20 compatible github actions

### DIFF
--- a/.github/workflows/icbundle.yml
+++ b/.github/workflows/icbundle.yml
@@ -19,7 +19,7 @@ jobs:
           sudo apt update
           sudo apt install -y w3m
       - name: Checkout IC Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: '0'
           ref: main


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #429, Adds node.js version 20 supported github action.

**Testing performed**
https://github.com/nasa/PSP/actions/workflows/icbundle.yml

**Expected behavior changes**
Suppresses cFS github warnings associated with deprecated node 16 versioned actions.

**System(s) tested on**
 - OS: Ubuntu 20.04

**Additional context**
Is https://github.com/nasa/PSP/actions/workflows/icbundle.yml still needed? Doesn't appear used.

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems
