### PR TITLE
PSP FreeRTOS Implementation

### DIFF
--- a/fsw/freertos/CMakeLists.txt
+++ b/fsw/freertos/CMakeLists.txt
@@ -1,6 +1,10 @@
 include_directories(inc)
 
 add_library(psp-${CFE_PSP_TARGETNAME}-impl OBJECT
-	src/cfe_psp_timer.c
+	src/cfe_psp_exceptions.c
+	src/cfe_psp_memory.c
+	src/cfe_psp_memtab.c
 	src/cfe_psp_support.c
+	src/cfe_psp_timer.c
+	src/cfe_psp_watchdog.c
 )

--- a/fsw/freertos/CMakeLists.txt
+++ b/fsw/freertos/CMakeLists.txt
@@ -1,0 +1,6 @@
+include_directories(inc)
+
+add_library(psp-${CFE_PSP_TARGETNAME}-impl OBJECT
+	src/cfe_psp_timer.c
+	src/cfe_psp_support.c
+)

--- a/fsw/freertos/inc/cfe_psp_config.h
+++ b/fsw/freertos/inc/cfe_psp_config.h
@@ -1,0 +1,12 @@
+#ifndef _cfe_psp_config_
+#define _cfe_psp_config_
+
+
+// FreeRTOS headers
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+#include "freertos/queue.h"
+
+
+#endif

--- a/fsw/freertos/inc/cfe_psp_config.h
+++ b/fsw/freertos/inc/cfe_psp_config.h
@@ -9,4 +9,8 @@
 #include "freertos/queue.h"
 
 
+// Watchdog
+#define CFE_PSP_WATCHDOG_MIN 0
+#define CFE_PSP_WATCHDOG_MAX 0xFFFFFFFF
+
 #endif

--- a/fsw/freertos/inc/psp_version.h
+++ b/fsw/freertos/inc/psp_version.h
@@ -1,0 +1,64 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*! @file freertos/inc/psp_version.h
+ *  @brief Purpose:
+ *  @details Provide version identifiers for the cFE Platform Support Packages (PSP).
+ *  See @ref cfsversions for version and build number and description
+ */
+#ifndef _psp_version_
+#define _psp_version_
+
+/*
+ * Development Build Macro Definitions
+ */
+#define CFE_PSP_IMPL_BUILD_NUMBER   1
+#define CFE_PSP_IMPL_BUILD_BASELINE "v0.0.1-rc1"
+
+/*
+ * Version Macro Definitions
+ */
+#define CFE_PSP_IMPL_MAJOR_VERSION 10/*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
+#define CFE_PSP_IMPL_MINOR_VERSION 0 /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
+#define CFE_PSP_IMPL_REVISION      1 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision number. */
+#define CFE_PSP_IMPL_MISSION_REV 99 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. A value of "99" indicates an unreleased development version.  */
+
+/*
+ * Tools to construct version string
+ */
+#define CFE_PSP_IMPL_STR_HELPER(x) #x /*!< @brief Helper function to concatenate strings from integer */
+#define CFE_PSP_IMPL_STR(x) \
+    CFE_PSP_IMPL_STR_HELPER(x) /*!< @brief Helper function to concatenate strings from integer */
+
+/*! @brief Development Build Version Number.
+ *  @details Baseline git tag + Number of commits since baseline. @n
+ *  See @ref cfsversions for format differences between development and release versions.
+ */
+#define CFE_PSP_IMPL_VERSION CFE_PSP_IMPL_BUILD_BASELINE CFE_PSP_IMPL_STR(CFE_PSP_IMPL_BUILD_NUMBER)
+
+/*! @brief Development Build Version String.
+ *  @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
+ * official version. @n See @ref cfsversions for format differences between development and release versions.
+ */
+#define CFE_PSP_IMPL_VERSION_STRING                                                       \
+    " PSP DEVELOPMENT BUILD " CFE_PSP_IMPL_VERSION /* Codename for current development */ \
+    ", Last Official Release: psp v0.0.0"          /* For full support please use this version */
+
+#endif /* _psp_version_ */

--- a/fsw/freertos/src/cfe_psp_exceptions.c
+++ b/fsw/freertos/src/cfe_psp_exceptions.c
@@ -1,0 +1,15 @@
+
+void CFE_PSP_AttachExceptions(void)
+{
+	/* TODO */
+}
+
+void CFE_PSP_SetDefaultExceptionEnvironment(void)
+{
+	/* TODO */
+}
+
+void CFE_PSP_ExceptionGetSummary_Impl(void *Buffer, char *ReasonBuf, uint32 ReasonSize)
+{
+	/* TODO (change buffer pointer) */
+}

--- a/fsw/freertos/src/cfe_psp_memory.c
+++ b/fsw/freertos/src/cfe_psp_memory.c
@@ -1,0 +1,16 @@
+#include "common_types.h"
+#include "osapi.h"
+
+// TODO: set blocksize of cds memory in reserved memory map
+init32 CFE_PSP_GetCDSSize(uint32 *SizeOfCDS)
+{
+	int32 return_code;
+
+	if (SizeOfCDS == NULL)
+	{
+		return OS_ERROR;
+	}
+
+	/* set blocksize of cds memory in reserved memory map */
+	return OS_SUCCESS;
+}

--- a/fsw/freertos/src/cfe_psp_memory.c
+++ b/fsw/freertos/src/cfe_psp_memory.c
@@ -1,16 +1,233 @@
-#include "common_types.h"
-#include "osapi.h"
+#include <sysLib.h>
 
-// TODO: set blocksize of cds memory in reserved memory map
+#include "cfe_psp.h"
+#include "cfe_psp_config.h"	// TODO: set up (for reservedbootrecord and memalign mask)
+#include "cfe_psp_memory.h"
+#include "common_types.h"	// defined in osal/src/os/inc
+
+/* macros */
+#define CFE_PSP_CDS_SIZE (GLOBAL_CONFIGDATA.CfeConfig->CdsSize)
+#define CFE_PSP_RESET_AREA_SIZE (GLOBAL_CONFIGDATA.CfeConfig->ResetAreaSize)
+#define CFE_PSP_USER_RESERVED_SIZE (GLOBAL_CONFIGDATA.CfeConfig->UserReservedSize)
+#define CFE_PSP_RAM_DISK_SECTOR_SIZE (GLOBAL_CONFIGDATA.CfeConfig->RamDiskSectorSize)
+#define CFE_PSP_RAM_DISK_NUM_SECTORS (GLOBAL_CONFIGDATA.CfeConfig->RamDiskTotalSectors)
+
+#define CFE_PSP_RESERVED_MEMORY_SIZE 200 * 1024
+
+#define CFE_PSP_BOOT_RECORD_SIZE (sizeof(CFE_PSP_ReservedMemoryBootRecord_t))
+#define CFE_PSP_EXCEPTION_RECORD_SIZE (sizeof(CFE_PSP_ExceptionStorage_t))
+
+
+#define memalign(x) (x + CFE_PSP_MEMALIGN_MASK) & ~CFE_PSP_MEMALIGN_MASK
+
+/* ------ */
+
+
+
+
+
+/* Global Variables */
+
+CFE_PSP_ReservedMemoryMap_t CFE_PSP_ReservedMemoryMap = { 0 };
+
+__attribute__ ((section(".psp_reserved")))
+__attribute__ ((aligned (8)))
+char pspReservedMemoryAlloc[CFE_PSP_RESERVED_MEMORY_SIZE];
+
+
+/* ---------------- */
+
+
+
+/* 
+ * CDS related functions
+ */
+
 init32 CFE_PSP_GetCDSSize(uint32 *SizeOfCDS)
 {
-	int32 return_code;
 
 	if (SizeOfCDS == NULL)
 	{
-		return OS_ERROR;
+		return CFE_PSP_ERROR;
+	}
+	
+	*SizeOfCDS = CFE_PSP_ReservedMemoryMap.CDSMemory.BlockSize;
+	
+	return CFE_PSP_SUCCESS;
+}
+
+
+int32 CFE_PSP_WriteToCDS(const void *PtrToDataToWrite, uint32 CDSOffset, uint32 NumBytes)
+{
+	uint8 *CopyPtr;
+
+	if (PtrToDataToWrite == NULL ||
+			(CDSOffset >= CFE_PSP_ReservedMemoryMap.CDSMemory.BlockSize) ||
+			((CDSOffset + NumBytes) > CFE_PSP_ReservedMemoryMap.CDSMemory.BlockSize))
+	{
+		return CFE_PSP_ERROR;
 	}
 
-	/* set blocksize of cds memory in reserved memory map */
-	return OS_SUCCESS;
+	CopyPtr = CFE_PSP_ReservedMemoryMap.CDSMemory.BlockPtr;
+	CopyPtr += CDSOffset;
+	memcpy((char *)CopyPtr, (char *)PtrToDataToWrite, NumBytes);
+
+	return CFE_PSP_SUCCESS;
 }
+
+int32 CFE_PSP_ReadFromCDS(void *PtrToDataToRead, uint32 CDSOffset, uint32 NumBytes)
+{
+	uint8 *CopyPtr;
+	
+	if (PtrToDataToRead == NULL ||
+			(CDSOffset >= CFE_PSP_ReservedMemoryMap.CDSMemory.BlockSize) ||
+			((CDSOffset + NumBytes) > CFE_PSP_ReservedMemoryMap.CDSMemory.BlockSize))
+	{
+		return CFE_PSP_ERROR;
+	}
+
+	CopyPtr = CFE_PSP_ReservedMemoryMap.CDSMemory.BlockPtr;
+	CopyPtr += CDSOffset;
+	memcpy((char *)PtrToDataToRead, (char *)CopyPtr, NumBytes);
+
+	return CFE_PSP_SUCCESS;
+}
+
+/*
+ * Reset Area related functions
+ */
+
+int32 CFE_PSP_GetResetArea(cpuaddr *PtrToResetArea, uint32 *SizeOfResetArea)
+{
+	if (PtrToResetArea == NULL || SizeOfResetArea == NULL)
+	{
+		return CFE_PSP_ERROR;
+	}
+
+	*PtrToResetArea = (cpuaddr)CFE_PSP_ReservedMemoryMap.ResetMemory.BlockPtr;
+	*SizeOfResetArea = CFE_PSP_ReservedMemoryMap.ResetMemory.BlockSize;
+	
+	return CFE_PSP_SUCCESS;
+}
+
+/*
+ * Reserved Area related functions
+ */
+
+int32 CFE_PSP_GetUserReservedArea(cpuaddr *PtrToUserArea, uint32 *SizeOfUserArea)
+{
+	if (PtrToUserArea == NULL || PtrToUserArea == NULL)
+	{
+		return CFE_PSP_ERROR;
+	}
+
+	*PtrToUserArea = (cpuaddr)CFE_PSP_ReservedMemoryMap.UserReservedMemory.BlockPtr;
+	*SizeOfUserArea = CFE_PSP_ReservedMemoryMap.UserReservedMemory.BlockSize;
+
+	return CFE_PSP_SUCCESS;
+}
+
+/*
+ * Volatile Disk Memory related functions
+ */
+
+int32 CFE_PSP_GetVolatileDiskMem(cpuaddr *PtrToVolDisk, uint32 *SizeOfVolDisk)
+{
+	if (PtrToVolDisk == NULL || SizeOfVolDisk == NULL)
+	{
+		return CFE_PSP_ERROR;
+	}
+
+	*PtrToVolDisk = (cpuaddr)CFE_PSP_ReservedMemoryMap.VolatileDiskMemory.BlockPtr;
+	*SizeOfVolDisk = CFE_PSP_ReservedMemoryMap.VolatileDiskMemory.BlockSize;
+
+	return CFE_PSP_SUCCESS;
+}
+
+/*
+ * Kernel Memory functions
+ */
+
+int32 CFE_PSP_GetKernelTextSegmentInfo(cpuaddr *PtrToKernelSegment, uint32 *SizeOfKernelSegment)
+{
+	cpuaddr StartAddress;
+	cpuaddr EndAddress;
+
+	if (SizeOfKernelSegment == NULL)
+	{
+		return CFE_PSP_ERROR;
+	}
+
+	StartAddress = 0; 	// TODO: get kernel start address
+	EndAddress = 0;		// TODO: get kernel end address
+	
+	*PtrToKernelSegment = StartAddress;
+	*SizeOfKernelSegment = (uint32)(EndAddress - StartAddress);
+
+	return CFE_PSP_SUCCESS;
+}
+
+/*
+ * Top Level Reserved Memory initialization
+ */
+
+int32 CFE_PSP_InitProcessorReservedMemory(uint32 RestartType)
+{
+	if (RestartType != CFE_PSP_RST_TYPE_PROCESSOR)
+	{
+		memset(ReservedMemBlock.BlockPtr, 0, ReservedMemBlock.BlockSize);
+
+		CFE_PSP_ReservedMemoryMap.BootPtr->bsp_reset_type = CFE_PSP_RST_TYPE_PROCESSOR;
+	}
+
+	return CFE_PSP_SUCCESS;
+}
+
+
+void CFE_PSP_SetupReservedMemoryMap(void)
+{
+	cpuaddr ReservedMemoryAddr;
+
+	size_t ResetSize = memalign(CFE_PSP_RESET_AREA_SIZE);
+	size_t CDSSize = memalign(CFE_PSP_CDS_SIZE);
+	size_t UserReservedSize = memalign(CFE_PSP_USER_RESERVED_SIZE);
+	size_t VolatileDiskSize = memalign(CFE_PSP_RAM_DISK_SECTOR_SIZE * CFE_PSP_RAM_DISK_NUM_SECTORS);
+	size_t RequiredSize = 0;
+
+	RequiredSize += ResetSize;
+	RequiredSize += CDSSize;
+	RequiredSize += UserReservedSize;
+	RequiredSize += VolatileDiskSize;
+
+	if ((unsigned int) RequiredSize > CFE_PSP_RESERVED_MEMORY_SIZE)
+	{
+		return;
+	}
+
+	ReservedMemoryAddr = pspReservedMemoryAlloc;
+
+	CFE_PSP_ReservedMemoryMap.BootPtr = (void *)ReservedMemoryAddr;	
+	ReservedMemoryAddr += CFE_PSP_BOOT_RECORD_SIZE;
+
+	CFE_PSP_ReservedMemoryMap.ExceptionStoragePtr = (void *)ReservedMemoryAddr;
+	ReservedMemoryAddr += CFE_PSP_EXCEPTION_RECORD_SIZE;
+	
+	CFE_PSP_ReservedMemoryMap.ResetMemory.BlockPtr = (void*) ReservedMemoryAddr;
+	CFE_PSP_ReservedMemoryMap.ResetMemory.BlockSize = CFE_PSP_RESET_AREA_SIZE;
+	ReservedMemoryAddr += ResetSize;
+
+	CFE_PSP_ReservedMemoryMap.VolatileDiskMemory.BlockPtr = (void*) ReservedMemoryAddr;
+	CFE_PSP_ReservedMemoryMap.VolatileDiskMemory.BlockSize = CFE_PSP_RAM_DISK_SECTOR_SIZE * CFE_PSP_RAM_DISK_NUM_SECTORS;
+	ReservedMemoryAddr += VolatileDiskSize;
+
+	CFE_PSP_ReservedMemoryMap.CDSMemory.BlockPtr = (void*) ReservedMemoryAddr;
+	CFE_PSP_ReservedMemoryMap.CDSMemory.BlockSize = CFE_PSP_CDS_SIZE;
+	ReservedMemoryAddr += CDSSize;
+
+	CFE_PSP_ReservedMemoryMap.UserReservedMemory.BlockPtr = (void*) ReservedMemoryAddr;
+	CFE_PSP_ReservedMemoryMap.UserReservedMemory.BlockSize = CFE_PSP_USER_RESERVED_SIZE;
+	ReservedMemoryAddr += UserReservedSize;
+}
+
+// TODO: is an action needed?
+void CFE_PSP_DeleteProcessorReservedMemory(void) {}

--- a/fsw/freertos/src/cfe_psp_memtab.c
+++ b/fsw/freertos/src/cfe_psp_memtab.c
@@ -1,0 +1,42 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+#include "common_types.h"
+#include "osapi.h"
+#include "cfe_psp.h"
+#include "cfe_psp_config.h"
+
+/*
+** Valid memory map for this target.
+** If you need to add more entries, increase CFE_PSP_MEM_TABLE_SIZE in the osconfig.h file.
+*/
+CFE_PSP_MemTable_t CFE_PSP_MemoryTable[CFE_PSP_MEM_TABLE_SIZE] = 
+{
+   { CFE_PSP_MEM_RAM, CFE_PSP_MEM_SIZE_DWORD, 0, 0xFFFFFFFF, CFE_PSP_MEM_ATTR_READWRITE },
+   { CFE_PSP_MEM_INVALID, 0, 0, 0, CFE_PSP_MEM_ATTR_READWRITE },
+   { CFE_PSP_MEM_INVALID, 0, 0, 0, CFE_PSP_MEM_ATTR_READWRITE },
+   { CFE_PSP_MEM_INVALID, 0, 0, 0, CFE_PSP_MEM_ATTR_READWRITE },
+   { CFE_PSP_MEM_INVALID, 0, 0, 0, CFE_PSP_MEM_ATTR_READWRITE },
+   { CFE_PSP_MEM_INVALID, 0, 0, 0, CFE_PSP_MEM_ATTR_READWRITE },
+   { CFE_PSP_MEM_INVALID, 0, 0, 0, CFE_PSP_MEM_ATTR_READWRITE },
+   { CFE_PSP_MEM_INVALID, 0, 0, 0, CFE_PSP_MEM_ATTR_READWRITE },
+   { CFE_PSP_MEM_INVALID, 0, 0, 0, CFE_PSP_MEM_ATTR_READWRITE },
+   { CFE_PSP_MEM_INVALID, 0, 0, 0, CFE_PSP_MEM_ATTR_READWRITE },
+};

--- a/fsw/freertos/src/cfe_psp_start.c
+++ b/fsw/freertos/src/cfe_psp_start.c
@@ -1,0 +1,66 @@
+#include "cfe_psp.h"
+#include "cfe_psp_config.h"
+
+#include "target_config.h"
+
+#define CFE_PSP_MAIN_FUNCTION (*GLOBAL_CONFIGDATA.CfeConfig->SystemMain)
+
+#define CFE_PSP_NONVOL_STARTUP_FILE (GLOBAL_CONFIGDATA.CfeConfig->NonvolStartupFile)
+
+
+// TODO: Fully implement after specifying the structure of the reserved memory map
+void CFE_PSP_Restart(uint32 resetType)
+{
+	if (resetType == CFE_PSP_RST_TYPE_POWERON) 
+	{
+		CFE_PSP_ReservedMemoryMap.BootPtr->bsp_reset_type = CFE_PSP_RST_TYPE_POWERON;
+		CFE_PSP_FlushCaches(1, ReservedMemBlock.BlockPtr, ReservedMemBlock.BlockSize);
+		/* TODO: reboot clear */
+	}
+	else
+	{
+		CFE_PSP_ReservedMemoryMap.BootPtr->bsp_reset_type = CFE_PSP_RST_TYPE_PROCESSOR;
+		CFE_PSP_FlushCaches(1, ReservedMemBlock.BlockPtr, ReservedMemBlock.BlockSize);
+		/* TODO: reboot normal */
+	}
+}
+
+
+/* TODO: review this implementation by pztrick */
+
+int CFE_PSP_Setup(void){
+	return CFE_PSP_SUCCESS;
+}
+
+void CFE_PSP_Panic(int32 ErrorCode){
+	__asm("bkpt 1");
+	// vTaskEndScheduler();
+	OS_ApplicationExit(ErrorCode);
+}
+
+// OSAL:main() invokes PSP:OS_Application_Startup() inside a FreeRTOS task
+void OS_Application_Startup(void){
+	int32 status;
+	uint32 reset_type;
+	uint32 reset_subtype;
+	
+	CFE_PSP_SetupReservedMemoryMap();
+
+	status = OS_API_Init();
+	if(status != OS_SUCCESS){
+		OS_ApplicationExit(status);
+	}
+
+	if(CFE_PSP_Setup() != CFE_PSP_SUCCESS){
+		CFE_PSP_Panic(CFE_PSP_ERROR);
+	}
+
+	// @FIXME should try to read reset_type from NVM BootPtr
+	reset_type = CFE_PSP_RST_TYPE_POWERON;
+	reset_subtype = CFE_PSP_RST_SUBTYPE_POWER_CYCLE;
+	CFE_PSP_InitProcessorReservedMemory(reset_type);
+
+	CFE_PSP_MAIN_FUNCTION(reset_type, reset_subtype, 1, CFE_PSP_NONVOL_STARTUP_FILE);
+
+	vTaskDelete(NULL);
+}

--- a/fsw/freertos/src/cfe_psp_start.c
+++ b/fsw/freertos/src/cfe_psp_start.c
@@ -1,3 +1,5 @@
+#include "cmsis_os.h"
+
 #include "cfe_psp.h"
 #include "cfe_psp_config.h"
 
@@ -8,20 +10,20 @@
 #define CFE_PSP_NONVOL_STARTUP_FILE (GLOBAL_CONFIGDATA.CfeConfig->NonvolStartupFile)
 
 
-// TODO: Fully implement after specifying the structure of the reserved memory map
 void CFE_PSP_Restart(uint32 resetType)
 {
 	if (resetType == CFE_PSP_RST_TYPE_POWERON) 
 	{
 		CFE_PSP_ReservedMemoryMap.BootPtr->bsp_reset_type = CFE_PSP_RST_TYPE_POWERON;
 		CFE_PSP_FlushCaches(1, ReservedMemBlock.BlockPtr, ReservedMemBlock.BlockSize);
-		/* TODO: reboot clear */
+		
+		NVIC_SystemReset();
 	}
 	else
 	{
 		CFE_PSP_ReservedMemoryMap.BootPtr->bsp_reset_type = CFE_PSP_RST_TYPE_PROCESSOR;
 		CFE_PSP_FlushCaches(1, ReservedMemBlock.BlockPtr, ReservedMemBlock.BlockSize);
-		/* TODO: reboot normal */
+		/* FIXME: reboot without wiping memory */
 	}
 }
 

--- a/fsw/freertos/src/cfe_psp_support.c
+++ b/fsw/freertos/src/cfe_psp_support.c
@@ -23,30 +23,6 @@
 #define CFE_PSP_SPACECRAFT_ID	(GLOBAL_CONFIGDATA.SpacecraftId)
 
 
-// TODO: Fully implement after specifying the structure of the reserved memory map
-void CFE_PSP_Restart(uint32 resetType)
-{
-	if (resetType == CFE_PSP_RST_TYPE_POWERON) 
-	{
-		/* set bootptr of reserved memory map */
-		/* flush caches */
-		/* reboot clear */
-	}
-	else
-	{
-		/* set bootptr of reserved memory map */
-		/* flush caches */
-		/* reboot normal */
-	}
-}
-
-// TODO
-void CFE_PSP_Panic(int32 errorCode)
-{
-	/* exit with a failure code */
-}
-
-
 // TODO
 void CFE_PSP_FlushCaches(uint32 type, void *address, uint32 size)
 {

--- a/fsw/freertos/src/cfe_psp_support.c
+++ b/fsw/freertos/src/cfe_psp_support.c
@@ -16,6 +16,8 @@
  * limitations under the License.
  ************************************************************************/
 
+#include "cmsis_os.h"
+
 #include "target_config.h"
 
 #define CFE_PSP_CPU_ID		(GLOBAL_CONFIGDATA.CpuId)
@@ -26,9 +28,21 @@
 // TODO
 void CFE_PSP_FlushCaches(uint32 type, void *address, uint32 size)
 {
-	/* flush cache of size at address */
-}
+	if (type != 1)
+	{
+		return;
+	}
+	uint32_t startAddr = (uint32_t) address;
+	uint32_t endAddr = startAddr + size;
 
+	startAddr &= ~31;
+	endAddr = (endAddr + 31) & ~31;
+
+	SCB_CleanInvalidateDCache_by_Addr((uint32_t *)startAddr, endAddr - startAddr);
+
+	__DSB();
+	__ISB();
+}
 
 uint32 CFE_PSP_GetProcessorId(void)
 {

--- a/fsw/freertos/src/cfe_psp_support.c
+++ b/fsw/freertos/src/cfe_psp_support.c
@@ -1,0 +1,71 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+#include "target_config.h"
+
+#define CFE_PSP_CPU_ID		(GLOBAL_CONFIGDATA.CpuId)
+#define CFE_PSP_CPU_NAME	(GLOBAL_CONFIGDATA.CpuName)
+#define CFE_PSP_SPACECRAFT_ID	(GLOBAL_CONFIGDATA.SpacecraftId)
+
+
+// TODO: Fully implement after specifying the structure of the reserved memory map
+void CFE_PSP_Restart(uint32 resetType)
+{
+	if (resetType == CFE_PSP_RST_TYPE_POWERON) 
+	{
+		/* set bootptr of reserved memory map */
+		/* flush caches */
+		/* reboot clear */
+	}
+	else
+	{
+		/* set bootptr of reserved memory map */
+		/* flush caches */
+		/* reboot normal */
+	}
+}
+
+// TODO
+void CFE_PSP_Panic(int32 errorCode)
+{
+	/* exit with a failure code */
+}
+
+
+// TODO
+void CFE_PSP_FlushCaches(uint32 type, void *address, uint32 size)
+{
+	/* flush cache of size at address */
+}
+
+
+uint32 CFE_PSP_GetProcessorId(void)
+{
+	return CFE_PSP_CPU_ID;
+}
+
+uint32 CFE_PSP_GetSpacecraftId(void)
+{
+	return CFE_PSP_SPACECRAFT_ID;
+}
+
+const char *CFE_PSP_GetProcessorName(void)
+{
+	return CFE_PSP_CPU_NAME;
+}
+

--- a/fsw/freertos/src/cfe_psp_timer.c
+++ b/fsw/freertos/src/cfe_psp_timer.c
@@ -9,3 +9,8 @@ uint32 CFE_PSP_GetTimerLow32Rollover(void)
 {
 	return 0;
 }
+
+void CFE_PSP_Get_Timebase(uint32 *Tbu, uint32 *Tbl)
+{
+	/* TODO */
+}

--- a/fsw/freertos/src/cfe_psp_timer.c
+++ b/fsw/freertos/src/cfe_psp_timer.c
@@ -12,5 +12,6 @@ uint32 CFE_PSP_GetTimerLow32Rollover(void)
 
 void CFE_PSP_Get_Timebase(uint32 *Tbu, uint32 *Tbl)
 {
-	/* TODO */
+	// SysTick is set up in HAL_Init
+	return xTaskGetTickCount;
 }

--- a/fsw/freertos/src/cfe_psp_timer.c
+++ b/fsw/freertos/src/cfe_psp_timer.c
@@ -1,0 +1,11 @@
+#define CFE_PSP_TIMER_TICKS_PER_SECOND ((int32) configTICK_RATE_HZ)
+
+uint32 CFE_PSP_GetTimerTicksPerSecond(void)
+{
+	return CFE_PSP_TIMER_TICKS_PER_SECOND;
+}
+
+uint32 CFE_PSP_GetTimerLow32Rollover(void)
+{
+	return 0;
+}

--- a/fsw/freertos/src/cfe_psp_watchdog.c
+++ b/fsw/freertos/src/cfe_psp_watchdog.c
@@ -1,0 +1,34 @@
+#include "cfe_psp.h"
+#include "cfe_psp_config.h"
+
+uint32 CFE_PSP_WatchdogValue = CFE_PSP_WATCHDOG_MAX;
+
+void CFE_PSP_WatchdogInit(void)
+{
+	CFE_PSP_WatchdogValue = CFE_PSP_WATCHDOG_MAX;
+}
+
+void CFE_PSP_WatchdogEnable(void)
+{
+	/* TODO */
+}
+
+void CFE_PSP_WatchdogDisable(void)
+{
+	/* TODO */
+}
+
+void CFE_PSP_WatchdogService(void)
+{
+	/* TODO */
+}
+
+uint32 CFE_PSP_WatchdogGet(void)
+{
+	return CFE_PSP_WatchdogValue;
+}
+
+void CFE_PSP_WatchdogSet(uint32 WatchdogValue)
+{
+	CFE_PSP_WatchdogValue = WatchdogValue;
+}


### PR DESCRIPTION


Started implementation of the necessary PSP functions for a setup with FreeRTOS.
No testing was done so far.

Still to be implemented:
CFE_PSP_Main
CFE_PSP_Restart
CFE_PSP_GetRestartType

CFE_PSP_Get_Timer_Tick
CFE_PSP_Get_Timebase
CFE_PSP_Get_Dec

CFE_PSP_GetKernelTextSegmentInfo
CFE_PSP_GetCFETextSegmentInfo

CFE_PSP_WatchdogEnable
CFE_PSP_WatchdogDisable
CFE_PSP_WatchdogService

CFE_PSP_InitSSR
CFE_PSP_Decompress
CFE_PSP_AttachExceptions
CFE_PSP_SetDefaultExceptionEnvironment

CFE_PSP_InitProcessorReservedMemory
CFE_PSP_DeleteProcessorReservedMemory

CFE_PSP_ExceptionGetSummary_Impl
