### PR TITLE
Fix #432, buffer error in the VxWorks sysmon module

### DIFF
--- a/fsw/modules/vxworks_sysmon/vxworks_sysmon.h
+++ b/fsw/modules/vxworks_sysmon/vxworks_sysmon.h
@@ -79,7 +79,7 @@ typedef struct vxworks_sysmon_cpuload_state
 
     osal_id_t   task_id;
 
-    uint8_t    num_cpus;
+    uint8_t    poll_core_no;
 
     vxworks_sysmon_cpuload_core_t per_core[VXWORKS_SYSMON_MAX_CPUS];
 

--- a/unit-test-coverage/modules/vxworks_sysmon/src/coveragetest-vxworks_sysmon.c
+++ b/unit-test-coverage/modules/vxworks_sysmon/src/coveragetest-vxworks_sysmon.c
@@ -297,17 +297,16 @@ void Test_UpdateStat_Nominal(void)
     UtAssert_True(vxworks_sysmon_global.cpu_load.per_core[0].avg_load == AvgLoad, "Nominal Case: 100 percents cpuload");
 
     /* Nominal Case: Max Cpu Num */
-    IdleTaskLoad = 0;
-    vxworks_sysmon_global.cpu_load.num_cpus = 1;
+    IdleTaskLoad                            = 0;
+    vxworks_sysmon_global.cpu_load.poll_core_no = 1 + VXWORKS_SYSMON_MAX_CPUS;
     vxworks_sysmon_update_stat(fmt, "IDLE", "", "", "", 95, 7990, IdleTaskLoad, 1998); /* Function under test */
-    UtAssert_True(vxworks_sysmon_global.cpu_load.num_cpus == 1, "Nominal Case: Max Cpu Nums");
+    UtAssert_UINT8_EQ(vxworks_sysmon_global.cpu_load.poll_core_no, 1);
 
     /* Nominal Case: Not Idle String */
     memset(&vxworks_sysmon_global, 0, sizeof(vxworks_sysmon_global));
     vxworks_sysmon_update_stat(fmt, "KERNEL", "", "", "", 95, 7990, 95, 1998); /* Function under test */
-    UtAssert_True(vxworks_sysmon_global.cpu_load.per_core[0].avg_load  == 0  && vxworks_sysmon_global.cpu_load.num_cpus == 0, 
-                  "Nominal Case: Not Idle String");
-
+    UtAssert_ZERO(vxworks_sysmon_global.cpu_load.per_core[0].avg_load);
+    UtAssert_UINT8_EQ(vxworks_sysmon_global.cpu_load.poll_core_no, 1);
 }
 
 void Test_Task_Nominal(void)
@@ -329,7 +328,6 @@ void Test_Task_Error(void)
 
     vxworks_sysmon_Task();
     UtAssert_True(vxworks_sysmon_global.cpu_load.should_run == false, "Error Case: Cannot Start Auxillary Clock");
-
 }
 
 /*
@@ -351,5 +349,4 @@ void UtTest_Setup(void)
     ADD_TEST(Test_UpdateStat_Nominal);
     ADD_TEST(Test_Task_Nominal);
     ADD_TEST(Test_Task_Error);
-
 }


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
The cpu number to poll was not range checked until _after_ the memset. This is not the correct order of operations, it must range the element number in the array before writing/clearing it.

Fixes #432

**Testing performed**
Run coverage tests

**Expected behavior changes**
No array overrun, no address sanitizer issues

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
