### PR TITLE
Fix #440 - rename parameter in CFE_PSP_MemSet handler to align with stub and actual code

### DIFF
--- a/ut-stubs/src/cfe_psp_memaccess_api_handlers.c
+++ b/ut-stubs/src/cfe_psp_memaccess_api_handlers.c
@@ -45,7 +45,7 @@ void UT_DefaultHandler_CFE_PSP_MemCpy(void *UserObj, UT_EntryKey_t FuncKey, cons
     /* CFE_PSP_MemCpy(void *dest, const void *src, uint32 size) */
     void *      dest = UT_Hook_GetArgValueByName(Context, "dest", void *);
     const void *src  = UT_Hook_GetArgValueByName(Context, "src", const void *);
-    uint32      size = UT_Hook_GetArgValueByName(Context, "size", uint32);
+    uint32      n    = UT_Hook_GetArgValueByName(Context, "n", uint32);
     int32       Status;
 
     UT_Stub_GetInt32StatusCode(Context, &Status);
@@ -65,13 +65,13 @@ void UT_DefaultHandler_CFE_PSP_MemSet(void *UserObj, UT_EntryKey_t FuncKey, cons
     /* int32 CFE_PSP_MemSet(void *dest, uint8 value, uint32 size) */
     void * dest  = UT_Hook_GetArgValueByName(Context, "dest", void *);
     uint8  value = UT_Hook_GetArgValueByName(Context, "value", uint8);
-    uint32 size  = UT_Hook_GetArgValueByName(Context, "size", uint32);
+    uint32 n     = UT_Hook_GetArgValueByName(Context, "n", uint32);
     int32  Status;
 
     UT_Stub_GetInt32StatusCode(Context, &Status);
     if (Status >= 0)
     {
-        memset(dest, value, size);
+        memset(dest, value, n);
     }
 }
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [X] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Addresses a mis-match with the parameter name in the CFE_PSP_MemSet handler and stub.

**Testing performed**
Built cFS with change, including coverage test that uncovered this issue.

**Expected behavior changes**
 - Behavior Change: Correct handler behavior.

**System(s) tested on**
Oracle Linux 8

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov