### PR TITLE
Fix #443, Correct minor bugs + typos in the VxWorks layer

### DIFF
--- a/fsw/mcp750-vxworks/src/cfe_psp_memory.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_memory.c
@@ -186,7 +186,7 @@ int32 CFE_PSP_ReadFromCDS(void *PtrToDataToRead, uint32 CDSOffset, uint32 NumByt
             return_code = CFE_PSP_ERROR;
         }
 
-    } /* end if PtrToDataToWrite == NULL */
+    } /* end if PtrToDataToRead == NULL */
 
     return return_code;
 }
@@ -319,9 +319,7 @@ int32 CFE_PSP_GetVolatileDiskMem(cpuaddr *PtrToVolDisk, uint32 *SizeOfVolDisk)
 */
 int32 CFE_PSP_InitProcessorReservedMemory(uint32 RestartType)
 {
-    int32 return_code;
-
-    if (RestartType != CFE_PSP_RST_TYPE_PROCESSOR)
+    if (RestartType == CFE_PSP_RST_TYPE_POWERON)
     {
         OS_printf("CFE_PSP: Clearing Processor Reserved Memory.\n");
         memset(MCP750_ReservedMemBlock.BlockPtr, 0, MCP750_ReservedMemBlock.BlockSize);
@@ -331,8 +329,8 @@ int32 CFE_PSP_InitProcessorReservedMemory(uint32 RestartType)
         */
         CFE_PSP_ReservedMemoryMap.BootPtr->bsp_reset_type = CFE_PSP_RST_TYPE_PROCESSOR;
     }
-    return_code = CFE_PSP_SUCCESS;
-    return return_code;
+
+    return CFE_PSP_SUCCESS;
 }
 
 /******************************************************************************
@@ -478,7 +476,7 @@ int32 CFE_PSP_GetCFETextSegmentInfo(cpuaddr *PtrToCFESegment, uint32 *SizeOfCFES
     MODULE_ID   cFEModuleId;
     MODULE_INFO cFEModuleInfo;
     cpuaddr     GetModuleIdAddr;
-    MODULE_ID (*GetModuldIdFunc)(void);
+    MODULE_ID (*GetModuleIdFunc)(void);
 
     if (PtrToCFESegment == NULL || SizeOfCFESegment == NULL)
     {
@@ -503,8 +501,8 @@ int32 CFE_PSP_GetCFETextSegmentInfo(cpuaddr *PtrToCFESegment, uint32 *SizeOfCFES
         return_code     = OS_SymbolLookup(&GetModuleIdAddr, "GetCfeCoreModuleID");
         if (return_code == OS_SUCCESS && GetModuleIdAddr != 0)
         {
-            GetModuldIdFunc = (MODULE_ID(*)(void))GetModuleIdAddr;
-            cFEModuleId     = GetModuldIdFunc();
+            GetModuleIdFunc = (MODULE_ID(*)(void))GetModuleIdAddr;
+            cFEModuleId     = GetModuleIdFunc();
         }
 
         /*

--- a/fsw/mcp750-vxworks/src/cfe_psp_start.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_start.c
@@ -169,8 +169,8 @@ void OS_Application_Startup(void)
     else if (reset_register & SYS_REG_BLRR_FBTN)
     {
         OS_printf("CFE_PSP: POWERON Reset: Front Panel Push Button Reset.\n");
-        reset_type    = CFE_PSP_RST_SUBTYPE_PUSH_BUTTON;
-        reset_subtype = 3;
+        reset_type    = CFE_PSP_RST_TYPE_POWERON;
+        reset_subtype = CFE_PSP_RST_SUBTYPE_PUSH_BUTTON;
     }
     else if (reset_register & SYS_REG_BLRR_WDT2)
     {

--- a/unit-test-coverage/mcp750-vxworks/src/coveragetest-cfe-psp-start.c
+++ b/unit-test-coverage/mcp750-vxworks/src/coveragetest-cfe-psp-start.c
@@ -120,8 +120,8 @@ void Test_OS_Application_Startup(void)
     *PCS_SYS_REG_BLRR = PCS_SYS_REG_BLRR_FBTN;
     UT_OS_Application_Startup();
     UtAssert_INT32_EQ(UT_GetStubCount(UT_KEY(PCS_SystemMain)), 5);
-    UtAssert_INT32_EQ(StartType.StartType, CFE_PSP_RST_SUBTYPE_PUSH_BUTTON);
-    UtAssert_INT32_EQ(StartType.StartSubtype, 3);
+    UtAssert_INT32_EQ(StartType.StartType, CFE_PSP_RST_TYPE_POWERON);
+    UtAssert_INT32_EQ(StartType.StartSubtype, CFE_PSP_RST_SUBTYPE_PUSH_BUTTON);
 
     *PCS_SYS_REG_BLRR = PCS_SYS_REG_BLRR_WDT2;
     UT_OS_Application_Startup();


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #443 
  - Correct typos
  - Remove redundant return variable in `CFE_PSP_InitProcessorReservedMemory` (always returns `CFE_PSP_SUCCESS` anyway)
  - Correct type/sub-type in one of the cases in `OS_Application_Startup`

**Testing performed**
GitHub CI actions all passing successfully and confirmed locally that test coverage is unaffected.

**Expected behavior changes**
Logic unchanged other than fixes mentioned above.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt