### PR TITLE
Fix #449, update PCS_malloc stub PoolSize overflow

### DIFF
--- a/unit-test-coverage/ut-stubs/src/PCS_stdlib_handlers.c
+++ b/unit-test-coverage/ut-stubs/src/PCS_stdlib_handlers.c
@@ -89,7 +89,11 @@ void UT_DefaultHandler_PCS_malloc(void *UserObj, UT_EntryKey_t FuncKey, const UT
         PoolStart = (PoolStart + MPOOL_ALIGN - 1) & ~((cpuaddr)MPOOL_ALIGN - 1);
         PoolSize  = PoolEnd - PoolStart;
 
-        if (PoolSize > (MPOOL_ALIGN * 2))
+        /*
+         * Verify PollSize is greater than minimun size and
+         * that PoolStart didn't go past the PoolEnd during alignment.
+         */
+        if (PoolSize > (MPOOL_ALIGN * 2) && PoolStart < PoolEnd)
         {
             Rec       = (struct MPOOL_REC *)PoolStart;
             NextBlock = PoolStart + MPOOL_ALIGN;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #449

**Testing performed**
Steps taken to test the contribution:
1. Ran coverage-ut-pc-rtems-testrunner

**Expected behavior changes**
1. Test coverage-ut-pc-rtems-testrunner now passes


**System(s) tested on**
 - OS: Docker Ubuntu22/arm64 on Mac M3 Pro

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Jose F. Martinez Pedraza / GSFC 582