### PR TITLE
Fix #452, rtems sysmom overflow buffer

### DIFF
--- a/fsw/modules/rtems_sysmon/rtems_sysmon.h
+++ b/fsw/modules/rtems_sysmon/rtems_sysmon.h
@@ -68,7 +68,7 @@ typedef struct rtems_sysmon_cpuload_state
     rtems_id   task_id;
     rtems_name task_name;
 
-    uint8_t    num_cpus;
+    uint8_t    poll_core_no;
     rtems_sysmon_cpuload_core_t per_core[RTEMS_SYSMON_MAX_CPUS];
 
 } rtems_sysmon_cpuload_state_t;

--- a/unit-test-coverage/modules/rtems_sysmon/src/coveragetest-rtems_sysmon.c
+++ b/unit-test-coverage/modules/rtems_sysmon/src/coveragetest-rtems_sysmon.c
@@ -300,7 +300,7 @@ void Test_Cpu_Visitor_Nominal(void)
     UT_TimeDivideData.IntValue = 100;
     UT_TimeDivideData.FraValue = 0;
 
-    UtAssert_BOOL_TRUE(rtems_cpu_usage_visitor(&Thread, &Arg));
+    UtAssert_BOOL_FALSE(rtems_cpu_usage_visitor(&Thread, &Arg));
     UtAssert_True(Arg.per_core[0].avg_load == 0xFFFFFF, "Nominal Case: 100 percents cpu utilization");
 
     /* Nominal Case Idle Task */
@@ -317,7 +317,7 @@ void Test_Cpu_Visitor_Nominal(void)
     UT_TimeDivideData.TotalElapsed = 10;
     UT_TimeDivideData.IdleUptimeElapsed = 5;
 
-    UtAssert_BOOL_TRUE(rtems_cpu_usage_visitor(&Thread, &Arg)); 
+    UtAssert_BOOL_FALSE(rtems_cpu_usage_visitor(&Thread, &Arg)); 
 
     AverageLoadCalc = 0x1000 * UT_TimeDivideData.IntValue / 100;
     AverageLoadCalc |= (AverageLoadCalc << 12);
@@ -337,7 +337,7 @@ void Test_Cpu_Visitor_Nominal(void)
     UT_TimeDivideData.TotalElapsed = 10; /* placeholder */
     UT_TimeDivideData.IdleUptimeElapsed = 5; /* placeholder*/
 
-    UtAssert_BOOL_TRUE(rtems_cpu_usage_visitor(&Thread, &Arg)); 
+    UtAssert_BOOL_FALSE(rtems_cpu_usage_visitor(&Thread, &Arg)); 
 
     /* convert int and fra part of percentages into integer. 
     ** Then convert into an percentages and normalizes out of 0x1000 
@@ -361,18 +361,18 @@ void Test_Cpu_Visitor_Nominal(void)
     UT_TimeDivideData.TotalElapsed = 0;
     UT_TimeDivideData.IdleUptimeElapsed = 0;
 
-    UtAssert_BOOL_TRUE(rtems_cpu_usage_visitor(&Thread, &Arg)); 
+    UtAssert_BOOL_FALSE(rtems_cpu_usage_visitor(&Thread, &Arg)); 
     UtAssert_True(Arg.per_core[0].avg_load == 0, "Nominal Case: 0 percents cpu utilization");
 
-    /* Nominal Case: Max Cpu not reach */
+    /* Nominal Case: polling cpu reaches RTEMS_SYSMON_MAX_CPUS */
     memset(UT_ThreadGetNameData.Name, 0, sizeof(UT_ThreadGetNameData.Name));
     memset(&Arg, 0, sizeof(Arg));
     memset(&UT_TimeDivideData, 0, sizeof(UT_TimeDivideData));
 
     strncpy(UT_ThreadGetNameData.Name, "IDLE", 4);
-    Arg.num_cpus = -1;
-    UtAssert_BOOL_FALSE(rtems_cpu_usage_visitor(&Thread, &Arg)); 
-    UtAssert_True(Arg.num_cpus == 0, "Nominal Case: CPU Number increment");
+    Arg.poll_core_no = RTEMS_SYSMON_MAX_CPUS;
+    UtAssert_BOOL_TRUE(rtems_cpu_usage_visitor(&Thread, &Arg)); 
+    UtAssert_True(Arg.poll_core_no == 0, "Nominal Case: cpu number reseted");
 
 }
 


### PR DESCRIPTION
Fix #452, rtems sysmom coverage test causes an buffer overflow.

**Checklist (Please check before submitting)**

* [ ] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
- Include explicitly what issue it addresses [e.g. Fixes #X]

**Testing performed**
Steps taken to test the contribution:
1. Run against RTEMS

2. Run unit test on linux
2. Make ENABLE_UNIT_TESTS=true SIMULATION=native
3. make install
4. make test
5. make lcov

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: xxx (if applicable)
 - Behavior Change: xxx (if applicable)
 - Or no impact to behavior

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLAs apply to only software contributions.
 Anh Van, GSFC
