### PR TITLE
Fix #320, return CFE_PSP_ERROR on failure in CFE_PSP_GetCFETextSegmentInfo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ A clear and concise description of what the contribution is.
 **Testing performed**
 Steps taken to test the contribution:
 1. Build steps '...'
-1. Execution steps '...'
+2. Execution steps '...'
 
 **Expected behavior changes**
 A clear and concise description of how this contribution will change behavior and level of impact.

--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -3,11 +3,11 @@ name: "CodeQL Analysis"
 on:
   push:
   pull_request:
-  
+
 jobs:
   codeql:
     name: Codeql
     uses: nasa/cFS/.github/workflows/codeql-reusable.yml@main
-    with: 
+    with:
       component-path: psp
       make: 'make -C build/native/default_cpu1/psp'

--- a/.github/workflows/icbundle.yml
+++ b/.github/workflows/icbundle.yml
@@ -59,13 +59,13 @@ jobs:
           done
           changelog_entry="${changelog_entry}\n${see_entry}\n"
           sed -ir "s|# Changelog|$changelog_entry|" CHANGELOG.md
-          
+
           buildnumber_entry=$'#define CFE_PSP_IMPL_BUILD_NUMBER   '${rev_num}
           sed -ir "s|#define CFE_PSP_IMPL_BUILD_NUMBER.*|$buildnumber_entry|" fsw/mcp750-vxworks/inc/psp_version.h
-          
+
           buildnumber_entry=$'#define CFE_PSP_IMPL_BUILD_NUMBER   '${rev_num}
           sed -ir "s|#define CFE_PSP_IMPL_BUILD_NUMBER.*|$buildnumber_entry|" fsw/pc-linux/inc/psp_version.h
-          
+
           buildnumber_entry=$'#define CFE_PSP_IMPL_BUILD_NUMBER   '${rev_num}
           sed -ir "s|#define CFE_PSP_IMPL_BUILD_NUMBER.*|$buildnumber_entry|" fsw/pc-rtems/inc/psp_version.h
       - name: Commit and Push Updates to IC Branch

--- a/fsw/mcp750-vxworks/src/cfe_psp_memory.c
+++ b/fsw/mcp750-vxworks/src/cfe_psp_memory.c
@@ -530,7 +530,7 @@ int32 CFE_PSP_GetCFETextSegmentInfo(cpuaddr *PtrToCFESegment, uint32 *SizeOfCFES
             }
             else
             {
-                return_code = CFE_PSP_SUCCESS;
+                return_code = CFE_PSP_ERROR;
             }
         }
     }

--- a/ut-stubs/src/cfe_psp_cds_api_handlers.c
+++ b/ut-stubs/src/cfe_psp_cds_api_handlers.c
@@ -17,7 +17,7 @@
  ************************************************************************/
 
 /*
-** File: ut_bsp_stubs.c
+** File: cfe_psp_cds_api_handlers.c
 **
 ** Purpose:
 ** Unit test stubs for BSP routines

--- a/ut-stubs/src/cfe_psp_exception_api_handlers.c
+++ b/ut-stubs/src/cfe_psp_exception_api_handlers.c
@@ -17,7 +17,7 @@
  ************************************************************************/
 
 /*
-** File: ut_bsp_stubs.c
+** File: cfe_psp_exception_api_handlers.c
 **
 ** Purpose:
 ** Unit test stubs for BSP routines

--- a/ut-stubs/src/cfe_psp_id_api_handlers.c
+++ b/ut-stubs/src/cfe_psp_id_api_handlers.c
@@ -17,7 +17,7 @@
  ************************************************************************/
 
 /*
-** File: ut_bsp_stubs.c
+** File: cfe_psp_id_api_handlers.c
 **
 ** Purpose:
 ** Unit test stubs for BSP routines

--- a/ut-stubs/src/cfe_psp_memrange_api_handlers.c
+++ b/ut-stubs/src/cfe_psp_memrange_api_handlers.c
@@ -17,7 +17,7 @@
  ************************************************************************/
 
 /*
-** File: ut_bsp_stubs.c
+** File: cfe_psp_memrange_api_handlers.c
 **
 ** Purpose:
 ** Unit test stubs for BSP routines

--- a/ut-stubs/src/cfe_psp_timertick_api_handlers.c
+++ b/ut-stubs/src/cfe_psp_timertick_api_handlers.c
@@ -17,7 +17,7 @@
  ************************************************************************/
 
 /*
-** File: ut_bsp_stubs.c
+** File: cfe_psp_timertick_api_handlers.c
 **
 ** Purpose:
 ** Unit test stubs for BSP routines

--- a/ut-stubs/src/cfe_psp_version_api_handlers.c
+++ b/ut-stubs/src/cfe_psp_version_api_handlers.c
@@ -17,7 +17,7 @@
  ************************************************************************/
 
 /*
-** File: ut_bsp_stubs.c
+** File: cfe_psp_version_api_handlers.c
 **
 ** Purpose:
 ** Unit test stubs for BSP routines

--- a/ut-stubs/src/cfe_psp_watchdog_api_handlers.c
+++ b/ut-stubs/src/cfe_psp_watchdog_api_handlers.c
@@ -17,7 +17,7 @@
  ************************************************************************/
 
 /*
-** File: ut_bsp_stubs.c
+** File: cfe_psp_watchdog_api_handlers.c
 **
 ** Purpose:
 ** Unit test stubs for BSP routines


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #320 
  - couple of typos fixed along the way

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Returns `CFE_PSP_ERROR` when `moduleInfoGet` fails - as expected.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt