### PR TITLE
Fix #461, set stdout to unbuffered on pc-linux

### DIFF
--- a/fsw/pc-linux/src/cfe_psp_start.c
+++ b/fsw/pc-linux/src/cfe_psp_start.c
@@ -236,6 +236,24 @@ void OS_Application_Startup(void)
     memset(&(CommandData), 0, sizeof(CFE_PSP_CommandData_t));
 
     /*
+     * Set console output to unbuffered
+     *
+     * This PSP uses "printf()" calls before OSAL is initialized,
+     * then changes to OS_printf().  Lines in OS_printf() are buffered
+     * by OSAL and then directly written to the STDOUT_FILENO.
+     *
+     * This can cause unexpected behavior where the early calls to
+     * printf() are seen after the OS_printf() calls, because they
+     * are being buffered in stdio.  This is especially true if the
+     * output is directed to a log file or pipe, where block buffering
+     * is the default, as opposed to line buffering.
+     *
+     * As the only usage of stdout is in the early log messages,
+     * turning off buffering should not have any real downside.
+     */
+    setbuf(stdout, NULL);
+
+    /*
     ** Process the arguments with getopt_long(), then
     ** start the cFE
     */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Sets standard output to be unbuffered on linux

**Testing performed**
Run CFS with standard output sent to a pipe, and confirm messages now appear in the same order in which they are generated.

**Expected behavior changes**
Messages appear in correct order

**System(s) tested on**
Debian

**Additional context**
This done unconditionally, thus it will be unbuffered on terminals as well as file/pipe output.  This should be fine, as stdout is only used for a handful of early messages, and it is generally not a good idea to mix different buffering strategies.  With this, the only buffering is done by OSAL as part of its `OS_printf()` function.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
