### PR TITLE
Fix #310, resolve TOCTOU race in EEPROM file creation

### DIFF
--- a/unit-test-coverage/modules/eeprom_mmap_file/coveragetest-eeprom_mmap_file.c
+++ b/unit-test-coverage/modules/eeprom_mmap_file/coveragetest-eeprom_mmap_file.c
@@ -71,28 +71,12 @@ void Test_eeprom_mmap_file_Init(void)
     UT_SetDeferredRetcode(UT_KEY(PCS_mmap), 1, -1);
     UtAssert_VOIDCALL(eeprom_mmap_file_Init(1));
 
-    /* fail to create new file file */
+    /* fail to open file */
     UT_SetDeferredRetcode(UT_KEY(PCS_open), 1, -1);
     UtAssert_VOIDCALL(eeprom_mmap_file_Init(1));
 
-    /* file exists */
-    UT_SetDefaultReturnValue(UT_KEY(PCS_stat), -1);
-    UtAssert_VOIDCALL(eeprom_mmap_file_Init(1));
-
-    /* fail to open existing file */
-    UT_SetDeferredRetcode(UT_KEY(PCS_open), 1, -1);
-    UtAssert_VOIDCALL(eeprom_mmap_file_Init(1));
-
-    /* fail to seek in existing file */
-    UT_SetDeferredRetcode(UT_KEY(PCS_lseek), 1, -1);
-    UtAssert_VOIDCALL(eeprom_mmap_file_Init(1));
-
-    /* write success in existing file */
-    UT_SetDeferredRetcode(UT_KEY(PCS_write), 1, 1);
-    UtAssert_VOIDCALL(eeprom_mmap_file_Init(1));
-
-    /* fail to write a byte in existing file */
-    UT_SetDeferredRetcode(UT_KEY(PCS_write), 1, -1);
+    /* fail to resize file */
+    UT_SetDeferredRetcode(UT_KEY(PCS_ftruncate), 1, -1);
     UtAssert_VOIDCALL(eeprom_mmap_file_Init(1));
 }
 

--- a/unit-test-coverage/ut-stubs/inc/PCS_unistd.h
+++ b/unit-test-coverage/ut-stubs/inc/PCS_unistd.h
@@ -43,6 +43,7 @@
 /* ----------------------------------------- */
 
 extern int         PCS_close(int fd);
+extern int         PCS_ftruncate(int fd, PCS_off_t len);
 extern PCS_gid_t   PCS_getegid(void);
 extern PCS_uid_t   PCS_geteuid(void);
 extern long int    PCS_gethostid(void);

--- a/unit-test-coverage/ut-stubs/override_inc/unistd.h
+++ b/unit-test-coverage/ut-stubs/override_inc/unistd.h
@@ -34,6 +34,7 @@
 #define STDERR_FILENO PCS_STDERR_FILENO
 
 #define close       PCS_close
+#define ftruncate   PCS_ftruncate
 #define getegid     PCS_getegid
 #define geteuid     PCS_geteuid
 #define gethostid   PCS_gethostid

--- a/unit-test-coverage/ut-stubs/src/PCS_unistd_stubs.c
+++ b/unit-test-coverage/ut-stubs/src/PCS_unistd_stubs.c
@@ -47,6 +47,23 @@ int PCS_close(int fd)
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for PCS_ftruncate()
+ * ----------------------------------------------------
+ */
+int PCS_ftruncate(int fd, PCS_off_t len)
+{
+    UT_GenStub_SetupReturnBuffer(PCS_ftruncate, int);
+
+    UT_GenStub_AddParam(PCS_ftruncate, int, fd);
+    UT_GenStub_AddParam(PCS_ftruncate, PCS_off_t, len);
+
+    UT_GenStub_Execute(PCS_ftruncate, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(PCS_ftruncate, int);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for PCS_getegid()
  * ----------------------------------------------------
  */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Do not "stat" the file before opening, simply open it with O_CREAT and then call ftruncate to make it the correct size.

Fixes #310

**Testing performed**
Build and run, confirm EEPROM.DAT file is created when needed and re-used when it exists

**Expected behavior changes**
No separate "stat()" call which constituted a time of check / time of use race condition.  It's also simpler this way.

**System(s) tested on**
Linux

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
