### PR TITLE
Hardening pc-linux Memory Validation via Dynamic /proc/self/maps Discovery

### DIFF
--- a/fsw/pc-linux/inc/cfe_psp_config.h
+++ b/fsw/pc-linux/inc/cfe_psp_config.h
@@ -29,7 +29,7 @@
 ** This define sets the number of memory ranges that are defined in the memory range definition
 ** table.
 */
-#define CFE_PSP_MEM_TABLE_SIZE 10
+#define CFE_PSP_MEM_TABLE_SIZE 128
 
 /**
  * This define sets the maximum number of exceptions

--- a/fsw/pc-linux/src/cfe_psp_memory.c
+++ b/fsw/pc-linux/src/cfe_psp_memory.c
@@ -583,16 +583,10 @@ int32 CFE_PSP_GetVolatileDiskMem(cpuaddr *PtrToVolDisk, uint32 *SizeOfVolDisk)
     return return_code;
 }
 
-/*
-*********************************************************************************
-** ES BSP Top Level Reserved memory initialization
-*********************************************************************************
-*/
-
 /******************************************************************************
 **
 **  Purpose:
-**    This function performs the top level reserved memory initialization.
+**    To populate the system memory table by parsing the /proc/self/maps file.
 **
 **  Arguments:
 **    (none)
@@ -600,6 +594,76 @@ int32 CFE_PSP_GetVolatileDiskMem(cpuaddr *PtrToVolDisk, uint32 *SizeOfVolDisk)
 **  Return:
 **    (none)
 */
+void CFE_PSP_InitMemoryTableFromProcMaps(void)
+{
+    FILE *              fp;
+    char                line[256];
+    uint32              range_num = 0;
+    unsigned long       start, end;
+    char                perms[5];
+    uint32              attributes;
+    CFE_PSP_MemTable_t *SysMemPtr;
+
+    /*
+    ** Open /proc/self/maps to identify the mapped regions
+    */
+    fp = fopen("/proc/self/maps", "r");
+    if (fp == NULL)
+    {
+        OS_printf("CFE_PSP: Could not open /proc/self/maps for memory validation setup\n");
+        return;
+    }
+
+    while (fgets(line, sizeof(line), fp) != NULL)
+    {
+        if (sscanf(line, "%lx-%lx %4s", &start, &end, perms) == 3)
+        {
+            attributes = 0;
+            if (perms[0] == 'r') attributes |= CFE_PSP_MEM_ATTR_READ;
+            if (perms[1] == 'w') attributes |= CFE_PSP_MEM_ATTR_WRITE;
+
+            /*
+            ** Skip regions that are neither readable nor writable
+            */
+            if (attributes == 0) continue;
+
+            /*
+            ** Check for merging with the previous range
+            ** Adjacent regions with the same attributes are merged to save table space.
+            */
+            if (range_num > 0)
+            {
+                SysMemPtr = &CFE_PSP_ReservedMemoryMap.SysMemoryTable[range_num - 1];
+                if (SysMemPtr->StartAddr + SysMemPtr->Size == (cpuaddr)start && SysMemPtr->Attributes == attributes)
+                {
+                    SysMemPtr->Size = (cpuaddr)end - SysMemPtr->StartAddr;
+                    continue;
+                }
+            }
+
+            if (range_num < CFE_PSP_MEM_TABLE_SIZE)
+            {
+                /*
+                ** Populate the next entry in the table
+                */
+                SysMemPtr             = &CFE_PSP_ReservedMemoryMap.SysMemoryTable[range_num];
+                SysMemPtr->MemoryType = CFE_PSP_MEM_RAM;
+                SysMemPtr->StartAddr  = (cpuaddr)start;
+                SysMemPtr->Size       = (size_t)(end - start);
+                SysMemPtr->WordSize   = CFE_PSP_MEM_SIZE_DWORD;
+                SysMemPtr->Attributes = attributes;
+                range_num++;
+            }
+            else
+            {
+                break;
+            }
+        }
+    }
+
+    fclose(fp);
+}
+
 void CFE_PSP_SetupReservedMemoryMap(void)
 {
     int tempFd;
@@ -628,13 +692,30 @@ void CFE_PSP_SetupReservedMemoryMap(void)
     CFE_PSP_InitUserReservedArea();
 
     /*
-     * Set up the "RAM" entry in the memory table.
-     * On Linux this is just encompasses the entire memory space, but an entry needs
-     * to exist so that CFE_PSP_ValidateMemRange() works as intended.
-     */
-    CFE_PSP_MemRangeSet(0, CFE_PSP_MEM_RAM, 0, SIZE_MAX, CFE_PSP_MEM_SIZE_DWORD, CFE_PSP_MEM_ATTR_READWRITE);
+    ** Populate the memory table.
+    ** On Linux each process has its own address space, so use /proc/self/maps 
+    ** to identify mapped and accessible address regions. 
+    */
+    CFE_PSP_InitMemoryTableFromProcMaps();
 }
 
+/*
+*********************************************************************************
+** ES BSP Top Level Reserved memory initialization
+*********************************************************************************
+*/
+
+/******************************************************************************
+**
+**  Purpose:
+**    This function performs the top level reserved memory initialization.
+**
+**  Arguments:
+**    RestartType - Type of restart (POWERON, PROCESSOR, etc.)
+**
+**  Return:
+**    CFE_PSP_SUCCESS
+*/
 int32 CFE_PSP_InitProcessorReservedMemory(uint32 RestartType)
 {
     /*

--- a/fsw/pc-linux/src/cfe_psp_memory.c
+++ b/fsw/pc-linux/src/cfe_psp_memory.c
@@ -693,29 +693,12 @@ void CFE_PSP_SetupReservedMemoryMap(void)
 
     /*
     ** Populate the memory table.
-    ** On Linux each process has its own address space, so use /proc/self/maps 
-    ** to identify mapped and accessible address regions. 
+    ** On Linux each process has its own address space, so use /proc/self/maps
+    ** to identify mapped and accessible address regions.
     */
     CFE_PSP_InitMemoryTableFromProcMaps();
 }
 
-/*
-*********************************************************************************
-** ES BSP Top Level Reserved memory initialization
-*********************************************************************************
-*/
-
-/******************************************************************************
-**
-**  Purpose:
-**    This function performs the top level reserved memory initialization.
-**
-**  Arguments:
-**    RestartType - Type of restart (POWERON, PROCESSOR, etc.)
-**
-**  Return:
-**    CFE_PSP_SUCCESS
-*/
 int32 CFE_PSP_InitProcessorReservedMemory(uint32 RestartType)
 {
     /*

--- a/fsw/pc-linux/src/cfe_psp_memory.c
+++ b/fsw/pc-linux/src/cfe_psp_memory.c
@@ -44,6 +44,7 @@
 #include <sys/ipc.h>
 #include <sys/shm.h>
 #include <fcntl.h>
+#include <stdbool.h>
 
 /*
 ** cFE includes
@@ -602,6 +603,7 @@ void CFE_PSP_InitMemoryTableFromProcMaps(void)
     unsigned long       start, end;
     char                perms[5];
     uint32              attributes;
+    bool                overflow = false;
     CFE_PSP_MemTable_t *SysMemPtr;
 
     /*
@@ -657,13 +659,44 @@ void CFE_PSP_InitMemoryTableFromProcMaps(void)
             }
             else
             {
-                OS_printf("CFE_PSP WARNING: /proc/self/maps exceeds CFE_PSP_MEM_TABLE_SIZE (%d). Truncating.\n", CFE_PSP_MEM_TABLE_SIZE);
+                overflow = true;
                 break;
             }
         }
     }
 
     fclose(fp);
+
+    /*
+    ** Fall back to permissive validation on overflow or empty map
+    */
+    if (overflow || range_num == 0)
+    {
+        if (overflow)
+        {
+            OS_printf("CFE_PSP WARNING: /proc/self/maps exceeds CFE_PSP_MEM_TABLE_SIZE (%d). "
+                      "Falling back to permissive validation.\n",
+                      CFE_PSP_MEM_TABLE_SIZE);
+        }
+        else
+        {
+            OS_printf("CFE_PSP WARNING: No valid memory ranges parsed from /proc/self/maps. "
+                      "Falling back to permissive validation.\n");
+        }
+
+        memset(CFE_PSP_ReservedMemoryMap.SysMemoryTable, 0, sizeof(CFE_PSP_ReservedMemoryMap.SysMemoryTable));
+        CFE_PSP_MemRangeSet(0, CFE_PSP_MEM_RAM, 0, SIZE_MAX, CFE_PSP_MEM_SIZE_DWORD, CFE_PSP_MEM_ATTR_READWRITE);
+        return;
+    }
+
+    /*
+    ** Clear any remaining unused entries
+    */
+    if (range_num < CFE_PSP_MEM_TABLE_SIZE)
+    {
+        memset(&CFE_PSP_ReservedMemoryMap.SysMemoryTable[range_num], 0,
+               (CFE_PSP_MEM_TABLE_SIZE - range_num) * sizeof(CFE_PSP_MemTable_t));
+    }
 }
 
 void CFE_PSP_SetupReservedMemoryMap(void)

--- a/fsw/pc-linux/src/cfe_psp_memory.c
+++ b/fsw/pc-linux/src/cfe_psp_memory.c
@@ -597,7 +597,7 @@ int32 CFE_PSP_GetVolatileDiskMem(cpuaddr *PtrToVolDisk, uint32 *SizeOfVolDisk)
 void CFE_PSP_InitMemoryTableFromProcMaps(void)
 {
     FILE *              fp;
-    char                line[256];
+    char                line[512];
     uint32              range_num = 0;
     unsigned long       start, end;
     char                perms[5];
@@ -610,7 +610,8 @@ void CFE_PSP_InitMemoryTableFromProcMaps(void)
     fp = fopen("/proc/self/maps", "r");
     if (fp == NULL)
     {
-        OS_printf("CFE_PSP: Could not open /proc/self/maps for memory validation setup\n");
+        OS_printf("CFE_PSP: Could not open /proc/self/maps. Falling back to permissive validation.\n");
+        CFE_PSP_MemRangeSet(0, CFE_PSP_MEM_RAM, 0, SIZE_MAX, CFE_PSP_MEM_SIZE_DWORD, CFE_PSP_MEM_ATTR_READWRITE);
         return;
     }
 
@@ -656,6 +657,7 @@ void CFE_PSP_InitMemoryTableFromProcMaps(void)
             }
             else
             {
+                OS_printf("CFE_PSP WARNING: /proc/self/maps exceeds CFE_PSP_MEM_TABLE_SIZE (%d). Truncating.\n", CFE_PSP_MEM_TABLE_SIZE);
                 break;
             }
         }


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.
(Sent before regarding the older version of the fix in the Checksum repo)

## Describe the contribution
Mitigates a root cause of memory related Denial of Service (DoS) vulnerabilities by hardening the `pc-linux` PSP memory validation layer.

Previously, the `pc-linux` PSP initialized its memory table with a permissive 0 to `SIZE_MAX` range, effectively bypassing all validation and masking potential security risks during development and simulation. This PR replaces that permissive range with a platform native discovery mechanism.

**Key Changes:**
- Implemented `CFE_PSP_InitMemoryTableFromProcMaps()`, which parses `/proc/self/maps` at startup to identify mapped and accessible memory regions.
- `CFE_PSP_MemValidateRange` now correctly enforces boundaries on Linux, rejecting invalid or unmapped addresses.
- Increased `CFE_PSP_MEM_TABLE_SIZE` to 128 to accommodate the fragmented nature of Linux virtual memory maps.
- Added an adjacent region merging (coalescing) algorithm to optimize the usage of the memory table while maintaining precise attribute mapping (Read/Write).

## Testing performed
1. Performed a clean build of `pc-linux` PSP to verify total compatibility and correct integration of the new `/proc` dependencies.
2. Instrumented `InitMemoryTableFromProcMaps` with console traces to confirm the `SysMemoryTable` accurately mirrors the process's real memory map.
3. Validated `CFE_PSP_MemValidateRange` behavior by confirming it correctly rejects unmapped addresses (e.g., `0xDEADBEEF`) while accepting valid data/stack segments.
4. Verified that identical adjacent memory segments are successfully merged, optimizing table usage and handling Linux fragmentation efficiently.

## Expected behavior changes
- `CFE_PSP_MemValidateRange` on the Linux platform will now **correctly** return failure (`CFE_PSP_INVALID_MEM_ADDR`) for non mapped addresses, rather than always returning `CFE_PSP_SUCCESS`.
- **API Change**: No changes to the PSP API signatures.
## System(s) tested on
- **Hardware**: PC (x86_64)
- **OS**: Linux (Generic)
- **Versions**: cFS / PSP Latest

## Additional context
Addresses the lack of platform native memory constraints on the `pc-linux` development platform, providing a security hardened reference for simulation based testing.

Fixes:- nasa/cFS#945

## Contributor Info
- Shrey Naithani
- Note: CLA was previously submitted for the same issue to the cFS ecosystem.