### PR TITLE
Part cFS/workflows#122, Add Internal Workflows

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,13 @@
+name: Add Issue or PR to Project
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened, ready_for_review, converted_to_draft]
+
+jobs:
+  add-to-project:
+    name: Add issue or pull request to project
+    uses: nasa/cFS/.github/workflows/add-to-project-reusable.yml@dev
+    secrets: inherit


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Part of an internal issue cFS/workflows#122

**Testing performed**
Tested in other repositories using same logic
- https://github.com/arielswalker/osal/actions/runs/24799074199?pr=4
- https://github.com/arielswalker/cFS/actions/runs/24797959464?pr=5

**Expected behavior changes**
When issues or PRs are made, they are added to a default project. 

**System(s) tested on**
GitHub Actions

**Additional context**
Relies on this [PR ](https://github.com/nasa/cFS/pull/970)that includes a reusable workflow that is needed on dev. In that PR, it is noted that someone with privileges need to add an org level secret for this workflow to run successfully. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH. 
