### PR TITLE
Fix nasa#482, used return value of backtrace in OS_printf() statement

### DIFF
--- a/fsw/pc-linux/src/cfe_psp_exception.c
+++ b/fsw/pc-linux/src/cfe_psp_exception.c
@@ -206,7 +206,8 @@ void CFE_PSP_AttachExceptions(void)
      * by calling it once we ensure that it is loaded and therefore
      * it is safe to use in a signal handler.
      */
-    backtrace(Addr, 1);
+    int bt_retvalue = backtrace(Addr, 1);
+    OS_printf("Number of addresses returned by backtrace = %d\n", bt_retvalue);
 
     OS_printf("CFE_PSP: %s called\n", __func__);
 


### PR DESCRIPTION
* [ ] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixed nasa#482 by using return value of backtrace in OS_printf() statement

**Testing performed**

**Expected behavior changes**
- A message will be printed on the screen when running the pc-linux psp whenever you are attaching an exception.  

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 18.04
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Michael Yang NASA/GSFC
