### PR TITLE
Fix nasa#484, will check the lseek() return value in linux_sysmon_upd…

### DIFF
--- a/fsw/modules/linux_sysmon/linux_sysmon.c
+++ b/fsw/modules/linux_sysmon/linux_sysmon.c
@@ -165,6 +165,7 @@ void linux_sysmon_update_schedstat(linux_sysmon_cpuload_state_t *state, int elap
     size_t        line_size;
     ssize_t       line_rdsz;
     char         *eol_p;
+    off_t         lseek_ret;
 
     linux_sysmon_cpuload_core_t *core_p;
 
@@ -172,7 +173,12 @@ void linux_sysmon_update_schedstat(linux_sysmon_cpuload_state_t *state, int elap
     highest_cpu_num = 0;
 
     /* Reset to beginning of file to re-read it */
-    lseek(state->dev_fd, 0, SEEK_SET);
+    lseek_ret = lseek(state->dev_fd, 0, SEEK_SET);
+
+    if (lseek_ret == -1)
+    {
+        OS_printf("CFE_PSP(linux_sysmon): lseek error: %s\n", strerror(errno));
+    }
 
     while (true)
     {


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [ ] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes nasa#484, will suppress ignored return value warning by casting lseek() as `(void)`

**Testing performed**

**Expected behavior changes**
- None

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 18.04
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Michael Yang NASA/GSFC
