### PR TITLE
Fix header guard macro typo in todimpl.h coverage stub

### DIFF
--- a/unit-test-coverage/ut-stubs/override_inc/rtems/score/todimpl.h
+++ b/unit-test-coverage/ut-stubs/override_inc/rtems/score/todimpl.h
@@ -17,7 +17,7 @@
  ************************************************************************/
 
 /* PSP coverage stub replacement for todimpl.h */
-#ifndef OVERRIDE_TOOIMPL_H
+#ifndef OVERRIDE_TODIMPL_H
 #define OVERRIDE_TODIMPL_H
 
 #include "PCS_todimpl.h"


### PR DESCRIPTION
**Describe the contribution**
Fixes the header guard typo reported in nasa/cFS#1039. In `unit-test-coverage/ut-stubs/override_inc/rtems/score/todimpl.h` the `#ifndef` guard read `OVERRIDE_TOOIMPL_H` (double O) while the `#define` on the next line reads `OVERRIDE_TODIMPL_H`. Clang's `-Werror=header-guard` rejects the mismatch, breaking the native build.

One-line change: align the `#ifndef` with the existing `#define`, matching the `OVERRIDE_<FILENAME>_H` convention used by the sibling override headers in the same directory (`threadimpl.h`, `timestampimpl.h`).

**Testing performed**
- Verified ifndef/define/filename now agree for this header and its siblings; checked all 58 override headers -- todimpl.h was the only mismatch.
- Grepped the repo to confirm the misspelled `OVERRIDE_TOOIMPL_H` is referenced nowhere else.
- Preprocess and double-include compile check of the header passes locally (GCC; the original clang -Wheader-guard diagnostic should be confirmed by CI).

**Expected behavior changes**
None at runtime; native builds with clang header-guard checking no longer fail.

**Contributor Info**
Sammy Dabbas, University of Central Florida