### PR TITLE
Fix mismatched header guard in todimpl.h coverage stub

### DIFF
--- a/unit-test-coverage/ut-stubs/override_inc/rtems/score/todimpl.h
+++ b/unit-test-coverage/ut-stubs/override_inc/rtems/score/todimpl.h
@@ -17,7 +17,7 @@
  ************************************************************************/
 
 /* PSP coverage stub replacement for todimpl.h */
-#ifndef OVERRIDE_TOOIMPL_H
+#ifndef OVERRIDE_TODIMPL_H
 #define OVERRIDE_TODIMPL_H
 
 #include "PCS_todimpl.h"


### PR DESCRIPTION
Fixes #491

**Describe the contribution**

The coverage stub `unit-test-coverage/ut-stubs/override_inc/rtems/score/todimpl.h` has a mismatched include guard. The `#ifndef` checks `OVERRIDE_TOOIMPL_H`, but the `#define` sets `OVERRIDE_TODIMPL_H`. Because the two names differ, the guard macro is never actually defined when the guard is evaluated, so the header is not protected against double inclusion.

This corrects the `#ifndef` to `OVERRIDE_TODIMPL_H` so it matches the `#define` and the file name, consistent with the other override stubs in this directory (for example `OVERRIDE_THREADIMPL_H` in `threadimpl.h`).

No functional or behavioral change is intended; this only repairs the include guard.

**Testing performed**

Built the `native_std` configuration (cFE, OSAL, PSP, and the sample apps) and confirmed the tree compiles and CFE boots to the OPERATIONAL state. The mismatch is also flagged by newer compilers under `-Wheader-guard`; with `-Werror` enabled this caused a build failure that is resolved by this change.

**Expected behavior changes**

None. The include guard now functions as intended.

**System(s) tested on**

- OS: Manjaro Linux (kernel 6.12)
- Compiler: GCC 16.1.1
- cFS bundle: current `dev`, PSP at the pinned submodule commit

**Additional context**

The mismatch surfaces as a hard error only on compilers that enable `-Wheader-guard` (such as recent GCC) when built with `-Werror`. On older compilers it is silent, which is likely why it has gone unnoticed.

**Contributor Info**

Camden Conrad (@camdenconrad)

