### PR TITLE
Fix #494, PSP RTEMS typo fix

### DIFF
--- a/unit-test-coverage/ut-stubs/override_inc/rtems/score/todimpl.h
+++ b/unit-test-coverage/ut-stubs/override_inc/rtems/score/todimpl.h
@@ -17,7 +17,7 @@
  ************************************************************************/
 
 /* PSP coverage stub replacement for todimpl.h */
-#ifndef OVERRIDE_TOOIMPL_H
+#ifndef OVERRIDE_TODIMPL_H
 #define OVERRIDE_TODIMPL_H
 
 #include "PCS_todimpl.h"


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
This is a typo fix (for Fix #494). The error appears when compiling a fresh copy of coreFlight using the OS Ubuntu 26.04 (Resolute Raccoon), the newest release of Ubuntu. This compiling error did not appear in previous versions of Ubuntu like 22.04 (Jammy Jellyfish) or 24.04 (Noble Numbat). It also doesn't show up in Red Hat.

**Testing performed**
Steps taken to test the contribution:
1. git clone https://github.com/nasa/cFS.git
2. cd cFS
3. git submodule init
4. git submodule update
5. make distclean
6. make native_std.prep (or make native_eds.prep)
7. make native_std.install (or make native_eds.install)


**Expected behavior changes**
Before, compiling a fresh copy of coreFlight while using Ubuntu Resolute Racoon, the following error would happen: 

<img width="968" height="259" alt="624538785-14eeb859-1f6f-4f86-bb0c-26c5a4a5f64c" src="https://github.com/user-attachments/assets/5f4eef93-f6a3-4876-ac65-21ec605e94bd" />

Code snips
https://github.com/nasa/PSP/blob/ce9126a61dd9233d6b33b92b9e65fca9989e7d5c/unit-test-coverage/ut-stubs/override_inc/rtems/score/todimpl.h
```
#ifndef OVERRIDE_TOOIMPL_H
#define OVERRIDE_TODIMPL_H
```
There is a typo here. The D and O in TODIMPL look so close.

After changing the typo, the code compiles correctly on Resolute Raccoon.