### PR TITLE
Fix #497, Remove Dead Functions

### DIFF
--- a/unit-test-coverage/shared/adaptors/inc/ut-adaptor-exceptions.h
+++ b/unit-test-coverage/shared/adaptors/inc/ut-adaptor-exceptions.h
@@ -42,12 +42,7 @@
 #include "cfe_psp_exceptionstorage_api.h"
 
 uint32 UT_Get_Exception_MaxEntries(void);
-size_t UT_Get_Exception_Size(void);
-size_t UT_Get_Exception_TotalStorageSize(void);
 uint32 UT_Get_Exception_Id(struct CFE_PSP_Exception_LogData *Buffer);
 void   UT_Generate_Exception_Context(struct CFE_PSP_Exception_LogData *Buffer, size_t Size);
-
-void UT_Set_Exception_StoragePtr(void *Ptr);
-void UT_Set_Exception_StorageReadWrite(uint32 rd, uint32 wr);
 
 #endif

--- a/unit-test-coverage/shared/adaptors/src/ut-adaptor-exceptions.c
+++ b/unit-test-coverage/shared/adaptors/src/ut-adaptor-exceptions.c
@@ -42,30 +42,9 @@
 #define CFE_PSP_MAX_EXCEPTION_ENTRIES        4
 #define CFE_PSP_MAX_EXCEPTION_BACKTRACE_SIZE 16
 
-void UT_Set_Exception_StoragePtr(void *Ptr)
-{
-    CFE_PSP_ReservedMemoryMap.ExceptionStoragePtr = Ptr;
-}
-
-void UT_Set_Exception_StorageReadWrite(uint32 rd, uint32 wr)
-{
-    CFE_PSP_ReservedMemoryMap.ExceptionStoragePtr->NumRead    = rd;
-    CFE_PSP_ReservedMemoryMap.ExceptionStoragePtr->NumWritten = wr;
-}
-
 uint32 UT_Get_Exception_MaxEntries(void)
 {
     return CFE_PSP_MAX_EXCEPTION_ENTRIES;
-}
-
-size_t UT_Get_Exception_Size(void)
-{
-    return sizeof(CFE_PSP_Exception_ContextDataEntry_t);
-}
-
-size_t UT_Get_Exception_TotalStorageSize(void)
-{
-    return sizeof(CFE_PSP_ExceptionStorage_t);
 }
 
 void UT_Generate_Exception_Context(struct CFE_PSP_Exception_LogData *Buffer, size_t Size)


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #497

**Testing performed**
Ran the native_std commands which includes prep, install, runtest, and lcov. Compared these lcov results against the unchanged cFS bundle and found no changes. Ran the old build commands with unit tests enabled to ensure that the internal static code analysis tool no longer flags these functions. Also ran the bundle with -Wunused flags which only flagged unrelated macros.

**Expected behavior changes**
Removes four dead functions
1. UT_Set_Exception_StorageReadWrite
2. UT_Get_Exception_Size
3. UT_Get_Exception_TotalStorageSize
4. UT_Set_Exception_StoragePtr

**System(s) tested on**
RedHat, cFS dev

**Additional context**
Lcov bundle results using native_std:
```
Overall coverage rate:
  lines......: 99.2% (30304 of 30537 lines)
  functions..: 99.2% (2428 of 2447 functions)
  branches...: no data found
```
Lcov bundle results using the old build commands:
```
Overall coverage rate:
  lines......: 99.2% (30167 of 30396 lines)
  functions..: 99.2% (2417 of 2436 functions)
  branches...: 98.7% (12931 of 13095 branches)
```
Static analysis workflow errors are pre-existing and documented in this [issue](https://github.com/nasa/PSP/issues/481)

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.
