### PR TITLE
Fix nasa#499, shmat() in cfe_psp_memory.c uses NULL instead of zero.

### DIFF
--- a/fsw/pc-linux/src/cfe_psp_memory.c
+++ b/fsw/pc-linux/src/cfe_psp_memory.c
@@ -164,7 +164,7 @@ void CFE_PSP_InitCDS(void)
     /*
     ** attach to the segment to get a pointer to it:
     */
-    CFE_PSP_ReservedMemoryMap.CDSMemory.BlockPtr = shmat(CDSShmId, (void *)0, 0);
+    CFE_PSP_ReservedMemoryMap.CDSMemory.BlockPtr = shmat(CDSShmId, NULL, 0);
     if (CFE_PSP_ReservedMemoryMap.CDSMemory.BlockPtr == (void *)(-1))
     {
         perror("CFE_PSP - Cannot shmat to CDS Shared memory Segment");
@@ -356,7 +356,7 @@ void CFE_PSP_InitResetArea(void)
     /*
     ** attach to the segment to get a pointer to it:
     */
-    block_addr = (cpuaddr)shmat(ResetAreaShmId, (void *)0, 0);
+    block_addr = (cpuaddr)shmat(ResetAreaShmId, NULL, 0);
     if (block_addr == (cpuaddr)(-1))
     {
         perror("CFE_PSP - Cannot shmat to Reset Area Shared memory Segment");
@@ -469,7 +469,7 @@ void CFE_PSP_InitUserReservedArea(void)
     /*
     ** attach to the segment to get a pointer to it:
     */
-    CFE_PSP_ReservedMemoryMap.UserReservedMemory.BlockPtr = shmat(UserShmId, (void *)0, 0);
+    CFE_PSP_ReservedMemoryMap.UserReservedMemory.BlockPtr = shmat(UserShmId, NULL, 0);
     if (CFE_PSP_ReservedMemoryMap.UserReservedMemory.BlockPtr == (void *)(-1))
     {
         perror("CFE_PSP - Cannot shmat to User Reserved Area Shared memory Segment");


### PR DESCRIPTION
* [ ] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #499 

**Expected behavior changes**
No Impact on Behavior

**Testing performed**
GitHub Actions and Axle

**Expected behavior changes**
Resolve Axle warnings on uninitialized variables

**System(s) tested on**
GitHub Actions and Axle.

**Contributor Info - All information REQUIRED for consideration of pull request**
Michael Yang / NASA GSFC

**For members of the cFS Team**
Click the `Preview` tab and select the pull request template corresponding to the type of change you are submitting:
- [Comment/Documentation Change](?expand=1&template=comment_documentation_change.md)
- [Flight Software Code Change](?expand=1&template=fsw_code_change.md)
- [Workflows Change](?expand=1&template=workflows_change.md)
